### PR TITLE
feat: 태그 수정 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@loadable/component": "^5.15.3",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.0.2",

--- a/src/components/thumbnail-maker/AddTagSection.tsx
+++ b/src/components/thumbnail-maker/AddTagSection.tsx
@@ -9,24 +9,9 @@ import {
 import { Button } from "../ui/button";
 import { Plus, SmilePlusIcon } from "lucide-react";
 import { useState } from "react";
+import { Tag, TagShape, TagVariant } from "./tag.types";
 
-export type TagVariant = "filled" | "outlined" | "ghost";
-export type TagShape = "round" | "squared";
-
-export function AddTagSection({
-  onAction,
-}: {
-  onAction: (
-    tag: {
-      text: string;
-      tagVariant: TagVariant;
-      tagShape: TagShape;
-    }
-    // inputValue: string,
-    // tagVariant: TagVariant,
-    // tagShape: TagShape
-  ) => void;
-}) {
+export function AddTagSection({ onAction }: { onAction: (tag: Tag) => void }) {
   const [inputValue, setInputValue] = useState("");
   const [tagVariant, setTagVariant] = useState<TagVariant>("filled");
   const [tagShape, setTagShape] = useState<TagShape>("round");

--- a/src/components/thumbnail-maker/TagItem.tsx
+++ b/src/components/thumbnail-maker/TagItem.tsx
@@ -1,28 +1,20 @@
 import { X } from "lucide-react";
 import { cn } from "src/lib/utils";
-import { TagVariant, TagShape } from "./AddTagSection";
 import { tagSize, tagStyle } from "./constants";
+import { Tag } from "./tag.types";
 
 export function TagItem({
   tag,
   onRemove,
+  onClick,
 }: {
-  tag: { text: string; tagVariant: TagVariant; tagShape: TagShape };
+  tag: Tag;
   onRemove: () => void;
+  onClick: () => void;
 }) {
   return (
-    <div className="group relative">
-      <div
-        style={{
-          ...tagSize.base,
-          ...tagStyle[`${tag.tagVariant}-${tag.tagShape}`],
-        }}
-        className={cn(
-          "relative flex min-w-fit max-w-full cursor-pointer items-center overflow-hidden truncate whitespace-nowrap rounded-full transition-all duration-300 ease-in-out"
-        )}
-      >
-        <span>{tag.text}</span>
-      </div>
+    <div className="group relative" onClick={onClick}>
+      <TagItemView tag={tag} />
       <div
         className="absolute -right-1 -top-1  hidden h-6 w-6 cursor-pointer justify-center rounded-full bg-white/80 p-0.5 align-middle group-hover:flex"
         onClick={(e) => {
@@ -32,6 +24,22 @@ export function TagItem({
       >
         <X size={20} color="#454545" />
       </div>
+    </div>
+  );
+}
+
+export function TagItemView({ tag }: { tag: Tag }) {
+  return (
+    <div
+      style={{
+        ...tagSize.base,
+        ...tagStyle[`${tag.tagVariant}-${tag.tagShape}`],
+      }}
+      className={cn(
+        "relative flex min-w-fit max-w-full cursor-pointer items-center overflow-hidden truncate whitespace-nowrap rounded-full transition-all duration-300 ease-in-out"
+      )}
+    >
+      <span>{tag.text}</span>
     </div>
   );
 }

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import {
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  Sheet,
+  SheetClose,
+  SheetFooter,
+} from "../ui/sheet";
+import { Tag } from "./tag.types";
+import { Button } from "../ui/button";
+import { TagItemView } from "./TagItem";
+import { Input } from "../ui/input";
+import { tagStyleMap } from "./constants";
+
+function TagSheet({
+  isOpen,
+  onClose,
+  tag: initTag,
+  onAction,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  tag: Tag;
+  onAction: (newTag: Tag) => void;
+}) {
+  const [tag, setTag] = useState<Tag>(initTag);
+
+  const onSaveClick = () => {
+    onAction(tag);
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>태그 변경하기</SheetTitle>
+          <SheetDescription>원하는대로 태그를 변경해보세요!</SheetDescription>
+        </SheetHeader>
+        <div className="flex min-w-fit flex-col gap-4 overflow-y-auto">
+          <div className="flex min-h-[200px] scale-50 items-center justify-center">
+            <TagItemView tag={tag} />
+          </div>
+          <div>
+            <p className="mb-4 text-sm text-white">태그 텍스트</p>
+            <Input
+              value={tag.text}
+              onChange={(e) => setTag({ ...tag, text: e.target.value })}
+            />
+          </div>
+          <div>
+            <p className="mb-4 text-sm text-white">태그 스타일</p>
+            <div className="flex flex-wrap gap-2">
+              {tagStyleMap.map((style) => {
+                const currentTag = {
+                  ...tag,
+                  tagVariant: style.variant,
+                  tagShape: style.shape,
+                };
+
+                return (
+                  <button
+                    key={style.variant + style.shape}
+                    className="h-fit w-fit origin-top-left scale-50 transform transition-all duration-300 ease-in-out"
+                    onClick={() => setTag(currentTag)}
+                  >
+                    <TagItemView tag={currentTag} />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        <SheetFooter>
+          {/* <SheetClose asChild> */}
+          <Button onClick={onSaveClick}>Save changes</Button>
+          {/* </SheetClose> */}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default TagSheet;

--- a/src/components/thumbnail-maker/constants.ts
+++ b/src/components/thumbnail-maker/constants.ts
@@ -1,3 +1,5 @@
+import { TagVariant, TagShape } from "./tag.types";
+
 export const PALLETTE = {
   gradient_blue: {
     bg: "linear-gradient(127deg, #8ECDF2 3.2%, #A0C8FC 21.06%, #A4C7FE 30.47%, #96BDFE 38.93%, #84B0FE 47.86%, #2B6FFF 97.22%)",
@@ -26,6 +28,13 @@ export const tagSize = {
     lineHeight: "normal",
   },
 };
+
+export const tagVariant: TagVariant[] = ["filled", "outlined", "ghost"];
+export const tagShape: TagShape[] = ["round", "squared"];
+
+export const tagStyleMap = tagVariant.flatMap((variant) =>
+  tagShape.map((shape) => ({ variant, shape }))
+);
 
 export const tagStyle = {
   "filled-round": {

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -2,13 +2,14 @@ import React, { useState, useRef, useEffect } from "react";
 import { Image } from "lucide-react";
 import { Button } from "../ui/button";
 import { PALLETTE } from "./constants";
-import { Tag } from "./types";
+import { Tag } from "./tag.types";
 import { AddTagSection } from "./AddTagSection";
 import { CanvasContainer } from "./CanvasContainer";
 import { TagItem } from "./TagItem";
 import { useCheckTagOverflow } from "./hooks/useCheckTagOverflow";
 import { usePreview } from "./hooks/usePreview";
 import { usePallette } from "./hooks/usePallette";
+import TagSheet from "./TagSheet";
 
 function ThumbnailMaker() {
   const { canvasBg, tagStyle } = usePallette();
@@ -17,6 +18,9 @@ function ThumbnailMaker() {
     useCheckTagOverflow();
 
   const [tags, setTags] = useState<Tag[]>([]);
+  const [openTagSheetIndex, setOpenTagSheetIndex] = useState<number | null>(
+    null
+  );
 
   const onTagsUpdate = (newTags: Tag[]) => {
     setTags(newTags);
@@ -41,6 +45,25 @@ function ThumbnailMaker() {
     });
   };
 
+  const handleChangeTag = async (newTag: Tag) => {
+    if (openTagSheetIndex === null) return;
+
+    const prevTags = [...tags];
+    const newTags = [...tags];
+    newTags[openTagSheetIndex] = newTag;
+    onTagsUpdate(newTags);
+
+    requestAnimationFrame(() => {
+      const overflow = checkOverflow();
+      if (overflow) {
+        showOverflowToast(overflow);
+        onTagsUpdate(prevTags);
+      } else {
+        setOpenTagSheetIndex(null);
+      }
+    });
+  };
+
   return (
     <div className="mx-auto max-w-[768px]">
       <h1 className="mb-7 text-center text-[80px] text-white">
@@ -58,10 +81,22 @@ function ThumbnailMaker() {
               key={index}
               tag={tag}
               onRemove={() => handleRemoveTag(index)}
+              onClick={() => setOpenTagSheetIndex(index)}
             />
           ))}
         </CanvasContainer>
       </div>
+      <TagSheet
+        key={openTagSheetIndex}
+        isOpen={openTagSheetIndex !== null}
+        onClose={() => setOpenTagSheetIndex(null)}
+        tag={
+          openTagSheetIndex !== null
+            ? tags[openTagSheetIndex]
+            : { text: "", tagVariant: "filled", tagShape: "round" }
+        }
+        onAction={handleChangeTag}
+      />
       <Button variant="secondary" onClick={onDownload} className="mt-6">
         <Image size={20} style={{ marginRight: "10px" }} /> 이미지 다운로드
       </Button>

--- a/src/components/thumbnail-maker/tag.types.d.ts
+++ b/src/components/thumbnail-maker/tag.types.d.ts
@@ -1,0 +1,4 @@
+export type TagVariant = "filled" | "outlined" | "ghost";
+export type TagShape = "round" | "squared";
+
+export type Tag = { text: string; tagVariant: TagVariant; tagShape: TagShape };

--- a/src/components/thumbnail-maker/types.d.ts
+++ b/src/components/thumbnail-maker/types.d.ts
@@ -1,1 +1,0 @@
-export type Tag = { text: string; tagVariant: TagVariant; tagShape: TagShape };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "src/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-[fit-content] min-w-[400px] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,6 +698,26 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
   integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
 
+"@radix-ui/react-dialog@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz#d9345575211d6f2d13e209e84aec9a8584b54d6c"
+  integrity sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.1"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-portal" "1.1.2"
+    "@radix-ui/react-presence" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.6.0"
+
 "@radix-ui/react-direction@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"


### PR DESCRIPTION
shadcn/ui의 sheet 컴포넌트를 이용해 추가한 태그를 수정할 수 있는 기능을 추가했어요. 
디자인은 아직 수정하지 않았고, 기능만 구현한 상태입니다. 
+ 태그를 수정할 때 수정된 태그로 인해 컨테이너가 넘치는지 체크하고 수정할 수 있도록 하였어요. 
- 컨테이너가 넘친다면, 넘쳐서 수정할 수 없다는 메시지를 띄웁니다. 

### 스크린샷
<img width="833" alt="스크린샷 2024-10-05 오전 12 04 34" src="https://github.com/user-attachments/assets/3dc0a5c9-aa6a-45c0-805e-fd019f669c03">
