### PR TITLE
feat: string tag list를 통해 태그 추가하기

### DIFF
--- a/src/components/thumbnail-maker/AddTagSection.tsx
+++ b/src/components/thumbnail-maker/AddTagSection.tsx
@@ -78,3 +78,36 @@ export function AddTagSection({ onAction }: { onAction: (tag: Tag) => void }) {
     </div>
   );
 }
+
+export function TagListInput({
+  onAction,
+}: {
+  onAction: (tags: Tag[]) => void;
+}) {
+  const dummy = "SVGO로, SVG 최적화, 🚀, Sprite 생성, ->, 성능 향상, 💾";
+  const [inputValue, setInputValue] = useState(dummy);
+
+  return (
+    <div>
+      <Input
+        placeholder="태그 리스트 등록"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
+      <Button
+        variant="secondary"
+        onClick={() =>
+          onAction(
+            inputValue.split(",").map((tag) => ({
+              text: tag,
+              tagVariant: "filled",
+              tagShape: "round",
+            }))
+          )
+        }
+      >
+        등록
+      </Button>
+    </div>
+  );
+}

--- a/src/components/thumbnail-maker/AddTagSection.tsx
+++ b/src/components/thumbnail-maker/AddTagSection.tsx
@@ -88,7 +88,7 @@ export function TagListInput({
   const [inputValue, setInputValue] = useState(dummy);
 
   return (
-    <div>
+    <div className="flex gap-4">
       <Input
         placeholder="태그 리스트 등록"
         value={inputValue}

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -3,7 +3,7 @@ import { Image } from "lucide-react";
 import { Button } from "../ui/button";
 import { PALLETTE } from "./constants";
 import { Tag } from "./tag.types";
-import { AddTagSection } from "./AddTagSection";
+import { AddTagSection, TagListInput } from "./AddTagSection";
 import { CanvasContainer } from "./CanvasContainer";
 import { TagItem } from "./TagItem";
 import { useCheckTagOverflow } from "./hooks/useCheckTagOverflow";
@@ -64,12 +64,19 @@ function ThumbnailMaker() {
     });
   };
 
+  const handleAddTags = (newTags: Tag[]) => {
+    onTagsUpdate(newTags);
+  };
+
   return (
     <div className="mx-auto max-w-[768px]">
       <h1 className="mb-7 text-center text-[80px] text-white">
         Thumbnail Maker
       </h1>
       <AddTagSection onAction={handleAddTag} />
+      <div>
+        <TagListInput onAction={handleAddTags} />
+      </div>
       <div className="mt-8">
         <CanvasContainer
           previewRef={previewRef}

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -74,7 +74,7 @@ function ThumbnailMaker() {
         Thumbnail Maker
       </h1>
       <AddTagSection onAction={handleAddTag} />
-      <div>
+      <div className="mt-4">
         <TagListInput onAction={handleAddTags} />
       </div>
       <div className="mt-8">


### PR DESCRIPTION
이후에 AI를 이용해 블로그 제목, 글에 따라 태그를 추천해주는 기능을 만들려고해요. 
그때 AI가 생성해준 태그를 쉽게 입력할 수 있도록 string으로 만들어진 태그 리스트를 캔버스에 추가하는 로직을 추가하였습니다. 

> 이후에 추가될 예정이며, 현재는 머지할 계획이 없습니다. 