### PR TITLE
feat: tag 수정 sheet 디자인 반영

### DIFF
--- a/src/components/thumbnail-maker/AddTagSection.tsx
+++ b/src/components/thumbnail-maker/AddTagSection.tsx
@@ -11,6 +11,7 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import { Tag, TagShape, TagVariant } from "./assets/palette.types";
 import { EmojiPicker } from "./EmojiPicker";
+import { EmojiType } from "../3d-emoji-picker";
 
 interface Props {
   onAction: (tag: Tag) => void;
@@ -23,13 +24,31 @@ export function AddTagSection({ onAction }: Props) {
 
   const onActionClick = async () => {
     if (inputValue.trim() === "") return;
+    const id = new Date().getTime();
 
     onAction({
-      text: inputValue,
+      id,
+      content: {
+        type: "text",
+        value: inputValue,
+      },
       tagVariant: tagVariant,
       tagShape: tagShape,
     });
     setInputValue("");
+  };
+
+  const onEmojiClick = (emoji: EmojiType) => {
+    const id = new Date().getTime();
+    onAction({
+      id,
+      content: {
+        type: "3d-emoji",
+        value: emoji,
+      },
+      tagShape: "emoji",
+      tagVariant: "ghost",
+    });
   };
 
   return (
@@ -77,16 +96,7 @@ export function AddTagSection({ onAction }: Props) {
       <Button onClick={onActionClick}>
         <Plus size={12} className="mr-3" /> Add
       </Button>
-      <EmojiPicker
-        onAction={(emoji) =>
-          onAction({
-            text: emoji,
-            tagContentType: "3d-emoji",
-            tagShape: "emoji",
-            tagVariant: "ghost",
-          })
-        }
-      />
+      <EmojiPicker onAction={onEmojiClick} />
     </div>
   );
 }

--- a/src/components/thumbnail-maker/TagEmojiSheet.tsx
+++ b/src/components/thumbnail-maker/TagEmojiSheet.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import {
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  Sheet,
+  SheetFooter,
+} from "../ui/sheet";
+import { Button } from "../ui/button";
+import { TagItemView } from "./TagItem";
+import { Input } from "../ui/input";
+import { getTagStyleKey } from "./assets/utils";
+import { useCurrentPaletteStyle } from "./Palette.context";
+import { Tag, TagShape, TagVariant } from "./assets/palette.types";
+import { EmojiType, ThreeDEmojiPicker } from "../3d-emoji-picker";
+
+const selectTagStyleMap: { variant: TagVariant; shape: TagShape }[] = [
+  { variant: "filled", shape: "round" },
+  { variant: "outlined", shape: "round" },
+  { variant: "ghost", shape: "squared" },
+  { variant: "filled", shape: "squared" },
+  { variant: "outlined", shape: "squared" },
+];
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+
+  tag: Tag;
+
+  onStyleChange: (newTag: Tag) => void;
+  onRemove: () => void;
+}
+
+function TagEmojiSheet({
+  isOpen,
+  onClose,
+  tag: initTag,
+  onStyleChange,
+  onRemove,
+}: Props) {
+  const paletteStyle = useCurrentPaletteStyle();
+  const [tag, setTag] = useState<Tag>(initTag);
+
+  const onChangeEmoji = (emoji: EmojiType) => {
+    setTag({ ...tag, content: { type: "3d-emoji", value: emoji } });
+  };
+
+  // NOTE: sheet open animation을 위해 useEffect 사용
+  useEffect(() => {
+    if (!initTag.content.value) return;
+    setTag(initTag);
+  }, [initTag]);
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent inner="center" className="!max-w-[410px] px-6">
+        <SheetHeader>
+          <SheetTitle>Change Emoji</SheetTitle>
+          <SheetDescription>
+            Try changing the emoji as you want!
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex min-w-fit flex-col overflow-y-auto pt-[14px]">
+          <div className="mb-12 flex min-h-[120px] w-full items-center justify-center rounded-[8px] bg-[#212129]">
+            <TagItemView
+              tag={tag}
+              tagStyle={paletteStyle.tagStyle[getTagStyleKey(tag)]}
+              size="small"
+            />
+          </div>
+          <div>
+            <ThreeDEmojiPicker onEmojiSelect={onChangeEmoji} />
+          </div>
+        </div>
+        <SheetFooter className="mt-[96px] flex justify-center gap-2 sm:justify-center">
+          <Button onClick={onRemove} variant="secondary">
+            Delete
+          </Button>
+          <Button onClick={() => onStyleChange(tag)}>Save</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default TagEmojiSheet;

--- a/src/components/thumbnail-maker/TagItem.tsx
+++ b/src/components/thumbnail-maker/TagItem.tsx
@@ -101,7 +101,7 @@ const tagVariants = cva(
       {
         variant: "outlined",
         size: "small",
-        className: "border-[2px] border-white/70",
+        className: "!border-[2px] border-white/70",
       },
       {
         variant: "ghost",

--- a/src/components/thumbnail-maker/TagItem.tsx
+++ b/src/components/thumbnail-maker/TagItem.tsx
@@ -37,13 +37,18 @@ export function TagItem({ tag, onRemove, onClick, className }: Props) {
 interface TagItemViewProps {
   tag: Tag;
   tagStyle: CSSProperties;
+  size?: "base" | "small";
 }
 
-export function TagItemView({ tag, tagStyle }: TagItemViewProps) {
+export function TagItemView({
+  tag,
+  tagStyle,
+  size = "base",
+}: TagItemViewProps) {
   return (
     <div
       className={cn(
-        tagVariants({ variant: tag.tagVariant, shape: tag.tagShape })
+        tagVariants({ variant: tag.tagVariant, shape: tag.tagShape, size })
       )}
       style={tagStyle}
     >
@@ -74,6 +79,7 @@ const tagVariants = cva(
       },
       size: {
         base: "h-[90px] text-[48px] font-bold leading-[90px]",
+        small: "h-[48px] text-[24px] font-bold leading-[48px] px-3",
       },
       shape: {
         round: "rounded-[45px]",
@@ -83,24 +89,24 @@ const tagVariants = cva(
     },
     compoundVariants: [
       {
-        variant: "filled",
         shape: "round",
-        className: "filled-round",
+        size: "small",
+        className: "px-3 rounded-[24px]",
       },
       {
-        variant: "filled",
         shape: "squared",
-        className: "filled-squared",
+        size: "small",
+        className: "px-3 rounded-[8px]",
       },
       {
         variant: "outlined",
-        shape: "round",
-        className: "outlined-round",
+        size: "small",
+        className: "border-[2px] border-white/70",
       },
       {
-        variant: "outlined",
-        shape: "squared",
-        className: "outlined-squared",
+        variant: "ghost",
+        size: "small",
+        className: "px-[7px]",
       },
     ],
     defaultVariants: {

--- a/src/components/thumbnail-maker/TagItem.tsx
+++ b/src/components/thumbnail-maker/TagItem.tsx
@@ -53,18 +53,17 @@ export function TagItemView({
       )}
       style={tagStyle}
     >
-      <span>
-        {tag.content.type === "3d-emoji" ? (
-          <img
-            src={get3DEmojiImage(tag.content.value)}
-            width={90}
-            height={90}
-            style={{ pointerEvents: "none" }}
-          />
-        ) : (
-          tag.content.value
-        )}
-      </span>
+      {tag.content.type === "3d-emoji" ? (
+        <img
+          src={get3DEmojiImage(tag.content.value)}
+          width={90}
+          height={90}
+          style={{ pointerEvents: "none" }}
+          className="h-full w-full"
+        />
+      ) : (
+        tag.content.value
+      )}
     </div>
   );
 }
@@ -108,6 +107,12 @@ const tagVariants = cva(
         variant: "ghost",
         size: "small",
         className: "px-[7px]",
+      },
+      {
+        variant: "ghost",
+        shape: "emoji",
+        size: "small",
+        className: "h-16 w-16",
       },
     ],
     defaultVariants: {

--- a/src/components/thumbnail-maker/TagItem.tsx
+++ b/src/components/thumbnail-maker/TagItem.tsx
@@ -5,6 +5,7 @@ import { getTagStyleKey } from "./assets/utils";
 import { useCurrentPaletteStyle } from "./Palette.context";
 import { Tag } from "./assets/palette.types";
 import { cva } from "class-variance-authority";
+import { get3DEmojiImage } from "../3d-emoji-picker";
 
 interface Props {
   tag: Tag;
@@ -53,15 +54,15 @@ export function TagItemView({
       style={tagStyle}
     >
       <span>
-        {tag.tagContentType === "3d-emoji" ? (
+        {tag.content.type === "3d-emoji" ? (
           <img
-            src={`https://avahrjwyynzeocqpyfhw.supabase.co/storage/v1/object/public/3d-fluent-emojis${tag.text.image}`}
+            src={get3DEmojiImage(tag.content.value)}
             width={90}
             height={90}
             style={{ pointerEvents: "none" }}
           />
         ) : (
-          tag.text
+          tag.content.value
         )}
       </span>
     </div>

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -25,8 +25,10 @@ const selectTagStyleMap: { variant: TagVariant; shape: TagShape }[] = [
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+
   tag: Tag;
-  onAction: (newTag: Tag) => void;
+
+  onStyleChange: (newTag: Tag) => void;
   onRemove: () => void;
 }
 
@@ -34,15 +36,19 @@ function TagSheet({
   isOpen,
   onClose,
   tag: initTag,
-  onAction,
+  onStyleChange,
   onRemove,
 }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
   const [tag, setTag] = useState<Tag>(initTag);
 
+  const onChangeTagStyle = (variant: TagVariant, shape: TagShape) => {
+    setTag({ ...tag, tagVariant: variant, tagShape: shape });
+  };
+
   // NOTE: sheet open animation을 위해 useEffect 사용
   useEffect(() => {
-    if (!initTag.text) return;
+    if (!initTag.content.value) return;
     setTag(initTag);
   }, [initTag]);
 
@@ -64,8 +70,13 @@ function TagSheet({
           <div className="mb-8">
             <p className="mb-3 text-[13px] text-[#9292A1]">Tag text</p>
             <Input
-              value={tag.text}
-              onChange={(e) => setTag({ ...tag, text: e.target.value })}
+              value={tag.content.value}
+              onChange={(e) =>
+                setTag({
+                  ...tag,
+                  content: { ...tag.content, value: e.target.value },
+                })
+              }
             />
           </div>
           <div>
@@ -73,9 +84,10 @@ function TagSheet({
             <div className="grid grid-cols-3 gap-4">
               {selectTagStyleMap.map((style) => {
                 const currentTag: Tag = {
+                  id: 0,
                   tagVariant: style.variant,
                   tagShape: style.shape,
-                  text: "TAG",
+                  content: { type: "text", value: "TAG" },
                 };
 
                 return (
@@ -83,7 +95,7 @@ function TagSheet({
                     key={getTagStyleKey(currentTag)}
                     type="button"
                     className="h-fit w-fit origin-top-left transform transition-all duration-300 ease-in-out"
-                    onClick={() => setTag({ ...currentTag, text: tag.text })}
+                    onClick={() => onChangeTagStyle(style.variant, style.shape)}
                   >
                     <TagItemView
                       tag={currentTag}
@@ -102,7 +114,7 @@ function TagSheet({
           <Button onClick={onRemove} variant="secondary">
             Delete
           </Button>
-          <Button onClick={() => onAction(tag)}>Save</Button>
+          <Button onClick={() => onStyleChange(tag)}>Save</Button>
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -33,6 +33,7 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
   const [tag, setTag] = useState<Tag>(initTag);
 
+  // NOTE: sheet open animation을 위해 useEffect 사용
   useEffect(() => {
     if (!initTag.text) return;
     setTag(initTag);

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -35,10 +35,10 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
 
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
-      <SheetContent>
+      <SheetContent inner="center">
         <SheetHeader>
-          <SheetTitle>태그 변경하기</SheetTitle>
-          <SheetDescription>원하는대로 태그를 변경해보세요!</SheetDescription>
+          <SheetTitle>Change Tag</SheetTitle>
+          <SheetDescription>Try changing the tag as you want!</SheetDescription>
         </SheetHeader>
         <div className="flex min-w-fit flex-col gap-4 overflow-y-auto">
           <div className="flex min-h-[200px] scale-50 items-center justify-center">

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   SheetContent,
   SheetHeader,
@@ -16,10 +16,10 @@ import { Tag, TagShape, TagVariant } from "./assets/palette.types";
 
 const selectTagStyleMap: { variant: TagVariant; shape: TagShape }[] = [
   { variant: "filled", shape: "round" },
-  { variant: "filled", shape: "squared" },
   { variant: "outlined", shape: "round" },
-  { variant: "outlined", shape: "squared" },
   { variant: "ghost", shape: "squared" },
+  { variant: "filled", shape: "squared" },
+  { variant: "outlined", shape: "squared" },
 ];
 
 interface Props {
@@ -33,6 +33,11 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
   const [tag, setTag] = useState<Tag>(initTag);
 
+  useEffect(() => {
+    if (!initTag.text) return;
+    setTag(initTag);
+  }, [initTag]);
+
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent inner="center">
@@ -40,35 +45,36 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
           <SheetTitle>Change Tag</SheetTitle>
           <SheetDescription>Try changing the tag as you want!</SheetDescription>
         </SheetHeader>
-        <div className="flex min-w-fit flex-col gap-4 overflow-y-auto">
-          <div className="flex min-h-[200px] scale-50 items-center justify-center">
+        <div className="flex min-w-fit flex-col overflow-y-auto pt-[14px]">
+          <div className="mb-12 flex min-h-[120px] w-full items-center justify-center rounded-[8px] bg-[#212129]">
             <TagItemView
               tag={tag}
               tagStyle={paletteStyle.tagStyle[getTagStyleKey(tag)]}
+              size="small"
             />
           </div>
-          <div>
-            <p className="mb-4 text-sm text-white">태그 텍스트</p>
+          <div className="mb-8">
+            <p className="mb-3 text-[13px] text-[#9292A1]">Tag text</p>
             <Input
               value={tag.text}
               onChange={(e) => setTag({ ...tag, text: e.target.value })}
             />
           </div>
           <div>
-            <p className="mb-4 text-sm text-white">태그 스타일</p>
-            <div className="flex flex-wrap gap-2">
+            <p className="mb-5 text-[13px] text-[#9292A1]">Tag style</p>
+            <div className="grid grid-cols-3 gap-4">
               {selectTagStyleMap.map((style) => {
                 const currentTag: Tag = {
                   tagVariant: style.variant,
                   tagShape: style.shape,
-                  text: "tag",
+                  text: "TAG",
                 };
 
                 return (
                   <button
                     key={getTagStyleKey(currentTag)}
                     type="button"
-                    className="h-fit w-fit origin-top-left scale-50 transform transition-all duration-300 ease-in-out"
+                    className="h-fit w-fit origin-top-left transform transition-all duration-300 ease-in-out"
                     onClick={() => setTag({ ...currentTag, text: tag.text })}
                   >
                     <TagItemView
@@ -76,6 +82,7 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
                       tagStyle={
                         paletteStyle.tagStyle[getTagStyleKey(currentTag)]
                       }
+                      size="small"
                     />
                   </button>
                 );
@@ -83,8 +90,11 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
             </div>
           </div>
         </div>
-        <SheetFooter>
-          <Button onClick={() => onAction(tag)}>Save changes</Button>
+        <SheetFooter className="mt-[96px] flex justify-center gap-2 sm:justify-center">
+          <Button onClick={() => onAction(tag)} variant="secondary">
+            Delete
+          </Button>
+          <Button onClick={() => onAction(tag)}>Save</Button>
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/src/components/thumbnail-maker/TagSheet.tsx
+++ b/src/components/thumbnail-maker/TagSheet.tsx
@@ -27,9 +27,16 @@ interface Props {
   onClose: () => void;
   tag: Tag;
   onAction: (newTag: Tag) => void;
+  onRemove: () => void;
 }
 
-function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
+function TagSheet({
+  isOpen,
+  onClose,
+  tag: initTag,
+  onAction,
+  onRemove,
+}: Props) {
   const paletteStyle = useCurrentPaletteStyle();
   const [tag, setTag] = useState<Tag>(initTag);
 
@@ -92,7 +99,7 @@ function TagSheet({ isOpen, onClose, tag: initTag, onAction }: Props) {
           </div>
         </div>
         <SheetFooter className="mt-[96px] flex justify-center gap-2 sm:justify-center">
-          <Button onClick={() => onAction(tag)} variant="secondary">
+          <Button onClick={onRemove} variant="secondary">
             Delete
           </Button>
           <Button onClick={() => onAction(tag)}>Save</Button>

--- a/src/components/thumbnail-maker/assets/palette.types.d.ts
+++ b/src/components/thumbnail-maker/assets/palette.types.d.ts
@@ -1,13 +1,21 @@
 export type TagVariant = "filled" | "outlined" | "ghost";
 export type TagShape = "round" | "squared" | "emoji";
 
-export type TagContentType = "text" | "3d-emoji";
+export type TagContentType =
+  | {
+      type: "text";
+      value: string;
+    }
+  | {
+      type: "3d-emoji";
+      value: EmojiType;
+    };
 
 export type Tag = {
-  text: string | EmojiType;
+  id: number;
+  content: TagContentType;
   tagVariant: TagVariant;
   tagShape: TagShape;
-  tagContentType?: TagContentType;
 };
 
 export type PaletteTag = `${TagVariant}-${TagShape}`;

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -98,6 +98,11 @@ function ThumbnailMaker() {
               : { text: "", tagVariant: "filled", tagShape: "round" }
           }
           onAction={handleChangeTag}
+          onRemove={() => {
+            if (openTagSheetIndex === null) return;
+            handleRemoveTag(openTagSheetIndex);
+            setOpenTagSheetIndex(null);
+          }}
         />
         <div className="flex items-center justify-between">
           <PallettePicker />

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -90,7 +90,6 @@ function ThumbnailMaker() {
           ))}
         </CanvasContainer>
         <TagSheet
-          key={openTagSheetIndex}
           isOpen={openTagSheetIndex !== null}
           onClose={() => setOpenTagSheetIndex(null)}
           tag={

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -11,6 +11,7 @@ import { PallettePicker } from "./PallettePicker";
 import { cn } from "src/lib/utils";
 import { PaletteProvider } from "./Palette.context";
 import { Tag } from "./assets/palette.types";
+import TagEmojiSheet from "./TagEmojiSheet";
 
 function ThumbnailMaker() {
   const { previewRef, onDownload } = usePreview();
@@ -80,9 +81,7 @@ function ThumbnailMaker() {
               key={index}
               tag={tag}
               onRemove={() => handleRemoveTag(index)}
-              onClick={() =>
-                tag.content.type !== "3d-emoji" && setOpenTagSheetIndex(index)
-              }
+              onClick={() => setOpenTagSheetIndex(index)}
               className={cn(
                 tag.content.type !== "3d-emoji" && "cursor-pointer"
               )}
@@ -90,7 +89,33 @@ function ThumbnailMaker() {
           ))}
         </CanvasContainer>
         <TagSheet
-          isOpen={openTagSheetIndex !== null}
+          isOpen={
+            openTagSheetIndex !== null &&
+            tags[openTagSheetIndex].content.type !== "3d-emoji"
+          }
+          onClose={() => setOpenTagSheetIndex(null)}
+          tag={
+            openTagSheetIndex !== null
+              ? tags[openTagSheetIndex]
+              : {
+                  id: 0,
+                  content: { type: "text", value: "" },
+                  tagVariant: "filled",
+                  tagShape: "round",
+                }
+          }
+          onStyleChange={handleChangeTag}
+          onRemove={() => {
+            if (openTagSheetIndex === null) return;
+            handleRemoveTag(openTagSheetIndex);
+            setOpenTagSheetIndex(null);
+          }}
+        />
+        <TagEmojiSheet
+          isOpen={
+            openTagSheetIndex !== null &&
+            tags[openTagSheetIndex].content.type === "3d-emoji"
+          }
           onClose={() => setOpenTagSheetIndex(null)}
           tag={
             openTagSheetIndex !== null

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -81,10 +81,10 @@ function ThumbnailMaker() {
               tag={tag}
               onRemove={() => handleRemoveTag(index)}
               onClick={() =>
-                tag.tagContentType !== "3d-emoji" && setOpenTagSheetIndex(index)
+                tag.content.type !== "3d-emoji" && setOpenTagSheetIndex(index)
               }
               className={cn(
-                tag.tagContentType ? "cursor-default" : "cursor-pointer"
+                tag.content.type !== "3d-emoji" && "cursor-pointer"
               )}
             />
           ))}
@@ -95,9 +95,14 @@ function ThumbnailMaker() {
           tag={
             openTagSheetIndex !== null
               ? tags[openTagSheetIndex]
-              : { text: "", tagVariant: "filled", tagShape: "round" }
+              : {
+                  id: 0,
+                  content: { type: "text", value: "" },
+                  tagVariant: "filled",
+                  tagShape: "round",
+                }
           }
-          onAction={handleChangeTag}
+          onStyleChange={handleChangeTag}
           onRemove={() => {
             if (openTagSheetIndex === null) return;
             handleRemoveTag(openTagSheetIndex);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -13,7 +13,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         // border-radius: 8px;
         // border: 1px solid var(--Gray-400, #464856);
         className={cn(
-          "flex h-[42px] w-full rounded-[8px] border border-[#464856] bg-transparent px-3 py-2 text-[15px] ring-offset-background file:border-0 file:bg-transparent file:text-[15px] file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-[42px] w-full rounded-[8px] border border-[#464856] bg-transparent px-3 py-2 text-[15px] outline-none",
+          "file:border-0 file:bg-transparent file:text-[15px] file:font-medium file:text-foreground placeholder:text-muted-foreground ",
+          "disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -40,9 +40,14 @@ const sheetVariants = cva(
         right:
           "inset-y-0 right-0 h-full w-[fit-content] min-w-[400px] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
+      inner: {
+        base: "",
+        center: "flex flex-col justify-center items-stretch",
+      },
     },
     defaultVariants: {
       side: "right",
+      inner: "base",
     },
   }
 );
@@ -54,12 +59,12 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", inner = "base", className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
-      className={cn(sheetVariants({ side }), className)}
+      className={cn(sheetVariants({ side, inner }), className)}
       {...props}
     >
       {children}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { cva, type VariantProps } from "class-variance-authority";
-import { X } from "lucide-react";
+import { ChevronLeft, ChevronsRightIcon, X } from "lucide-react";
 
 import { cn } from "src/lib/utils";
 
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-[#2A2A33] p-10 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
@@ -38,7 +38,7 @@ const sheetVariants = cva(
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-[fit-content] min-w-[400px] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-[fit-content] min-w-[375px] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
       inner: {
         base: "",
@@ -68,8 +68,8 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
+      <SheetPrimitive.Close className="absolute left-[26px] top-[26px] ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <ChevronsRightIcon className="h-6 w-6" color="#fff" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>


### PR DESCRIPTION
태그 수정 시트 디자인을 수정하였습니다. 
작은 태그 컴포넌트도 추가하였어요. 
<img width="714" alt="image" src="https://github.com/user-attachments/assets/6f7ccc18-8381-40a1-9a26-b7e49673bded">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- `TagItemView` 컴포넌트에 크기 매개변수 추가: "base" 및 "small" 옵션 지원.
	- `TagSheet` 컴포넌트에 태그 삭제 기능 추가 및 "삭제" 버튼 추가.
	- 이모지 선택 기능 추가 및 이모지 태그에 대한 새로운 구조화된 페이로드 생성.

- **버그 수정**
	- `useEffect`를 통해 `initTag` 변경 시 상태 업데이트 보장.

- **문서화**
	- `SheetTitle` 및 `SheetDescription` 텍스트를 영어로 번역.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->