### PR TITLE
fix: isComposing 추가하여 한글 엔터 에러 수정

### DIFF
--- a/src/components/thumbnail-maker/AddTagSection.tsx
+++ b/src/components/thumbnail-maker/AddTagSection.tsx
@@ -24,6 +24,7 @@ export function AddTagSection({ onAction }: Props) {
 
   const onActionClick = async () => {
     if (inputValue.trim() === "") return;
+
     const id = new Date().getTime();
 
     onAction({
@@ -60,6 +61,7 @@ export function AddTagSection({ onAction }: Props) {
         placeholder="Enter a tag"
         // enter 누르면
         onKeyDown={(e) => {
+          if (e.nativeEvent.isComposing || e.keyCode === 229) return;
           if (e.key === "Enter") {
             onActionClick();
           }


### PR DESCRIPTION
![엔터](https://github.com/user-attachments/assets/5c2a0a85-258e-468e-add2-ae2907020efd)
한글을 입력할 때 엔터 이벤트가 두번 감지되는 현상을 수정하였습니다. 

한글 입력 시 composing 단계를 거치는데 이게 완료가 되지 않아, 
key가 'Enter'가 아니거나 keyCode가 `229`가 되는 문제가 있어 이를 대응하도록 하였습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 태그 입력 처리 개선: 입력 중에 발생할 수 있는 문제를 방지하기 위한 체크 추가.
	- 각 태그에 대해 고유한 ID 생성 기능 추가.

- **버그 수정**
	- 동아시아 언어 입력 방법 사용 시 잘못된 태그 제출 방지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->