### PR TITLE
태그 스타일 랜덤 기능 추가

### DIFF
--- a/src/components/thumbnail-maker/SubMenu/SubActionMenu.tsx
+++ b/src/components/thumbnail-maker/SubMenu/SubActionMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu } from "lucide-react";
 import { Button } from "../../ui/button";
-import { useTagAction,   } from "../Tag.context";
+import { useTagAction } from "../Tag.context";
 import { ImageIcon, LayoutTemplateIcon } from "lucide-react";
 import {
   Menubar,

--- a/src/components/thumbnail-maker/Tag.context.tsx
+++ b/src/components/thumbnail-maker/Tag.context.tsx
@@ -13,6 +13,8 @@ interface TagActionContextType {
   onResetTags: () => void;
   onRollbackTags: () => void;
   onUpdateTagOrder: (newTags: Tag[]) => void;
+
+  onRandomShuffle: () => void;
 }
 
 const TagListContext = createContext<TagListContextType | undefined>({
@@ -25,6 +27,7 @@ const TagActionContext = createContext<TagActionContextType | undefined>({
   onResetTags: () => {},
   onRollbackTags: () => {},
   onUpdateTagOrder: () => {},
+  onRandomShuffle: () => {},
 });
 
 interface SelectTagContextType {
@@ -55,6 +58,7 @@ export const TagProvider = ({ children }: PropsWithChildren) => {
     onResetTags,
     onRollbackTags,
     onUpdateTagOrder,
+    onRandomShuffle,
   } = useThumbnailTagList();
 
   const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
@@ -77,6 +81,7 @@ export const TagProvider = ({ children }: PropsWithChildren) => {
           onResetTags,
           onRollbackTags,
           onUpdateTagOrder,
+          onRandomShuffle,
         }}
       >
         <SelectedTagContext.Provider value={{ selectedTag }}>

--- a/src/components/thumbnail-maker/assets/palette.constants.ts
+++ b/src/components/thumbnail-maker/assets/palette.constants.ts
@@ -1,4 +1,21 @@
-import { PaletteStyle, PaletteVariant } from "./palette.types";
+import {
+  PaletteStyle,
+  PaletteVariant,
+  TagShape,
+  TagVariant,
+} from "./palette.types";
+
+export const TAG_STYLE_COMBINATIONS: {
+  variant: TagVariant;
+  shape: TagShape;
+}[] = [
+  { variant: "filled", shape: "round" },
+  { variant: "filled", shape: "squared" },
+  { variant: "outlined", shape: "round" },
+  { variant: "outlined", shape: "squared" },
+  { variant: "ghost", shape: "round" },
+  { variant: "ghost", shape: "squared" },
+];
 
 export const PALETTE: Record<PaletteVariant, PaletteStyle> = {
   blue_gradient: {

--- a/src/components/thumbnail-maker/assets/utils.ts
+++ b/src/components/thumbnail-maker/assets/utils.ts
@@ -4,6 +4,11 @@ export const getTagStyleKey = (tag: Tag) => {
   return `${tag.tagVariant}-${tag.tagShape}` as const as PaletteTag;
 };
 
+/**
+ * 태그 스타일 조합을 정의하는 타입
+ * @property tagVariant - 태그의 변형 스타일 (filled, outlined, ghost)
+ * @property tagShape - 태그의 모양 (round, squared)
+ */
 type StyleCombination = {
   tagVariant: TagVariant;
   tagShape: TagShape;

--- a/src/components/thumbnail-maker/assets/utils.ts
+++ b/src/components/thumbnail-maker/assets/utils.ts
@@ -1,5 +1,57 @@
-import { Tag, PaletteTag } from "./palette.types";
+import { Tag, PaletteTag, TagVariant, TagShape } from "./palette.types";
 
 export const getTagStyleKey = (tag: Tag) => {
   return `${tag.tagVariant}-${tag.tagShape}` as const as PaletteTag;
+};
+
+type StyleCombination = {
+  tagVariant: TagVariant;
+  tagShape: TagShape;
+};
+
+export const getStyleCombinations = (): StyleCombination[] => [
+  { tagVariant: "filled", tagShape: "round" },
+  { tagVariant: "filled", tagShape: "squared" },
+  { tagVariant: "outlined", tagShape: "round" },
+  { tagVariant: "outlined", tagShape: "squared" },
+  { tagVariant: "ghost", tagShape: "round" },
+  { tagVariant: "ghost", tagShape: "squared" },
+];
+
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const newArray = [...array];
+  for (let i = newArray.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+  }
+  return newArray;
+};
+
+export const getRandomTagStyles = (tags: Tag[]): Tag[] => {
+  const styleCombinations = getStyleCombinations();
+  const shuffledStyles = shuffleArray(styleCombinations);
+
+  return tags.map((tag, index) => {
+    // emoji shape를 가진 태그는 스타일 변경하지 않음
+    if (tag.tagShape === "emoji") {
+      return tag;
+    }
+
+    let styleIndex = index % shuffledStyles.length;
+    if (index > 0 && tags[index - 1].tagShape !== "emoji") {
+      const prevStyle = tags[index - 1];
+      while (
+        prevStyle.tagVariant === shuffledStyles[styleIndex].tagVariant &&
+        prevStyle.tagShape === shuffledStyles[styleIndex].tagShape
+      ) {
+        styleIndex = (styleIndex + 1) % shuffledStyles.length;
+      }
+    }
+
+    return {
+      ...tag,
+      tagVariant: shuffledStyles[styleIndex].tagVariant,
+      tagShape: shuffledStyles[styleIndex].tagShape,
+    };
+  });
 };

--- a/src/components/thumbnail-maker/hooks/useThumbnailTagList.ts
+++ b/src/components/thumbnail-maker/hooks/useThumbnailTagList.ts
@@ -2,6 +2,7 @@ import useStorageState from "use-storage-state";
 import { THUMBNAIL_MAKER_STORAGE_KEY } from "../assets/constants";
 import { Tag } from "../assets/palette.types";
 import { useRef } from "react";
+import { getRandomTagStyles } from "../assets/utils";
 
 export function useThumbnailTagList() {
   const [tags, setTags] = useStorageState<Tag[]>(THUMBNAIL_MAKER_STORAGE_KEY, {
@@ -45,6 +46,11 @@ export function useThumbnailTagList() {
     setTags([]);
   };
 
+  const onRandomShuffle = () => {
+    const newTags = getRandomTagStyles(tags);
+    setTags(newTags);
+  };
+
   return {
     tags,
     onAddTag,
@@ -53,5 +59,6 @@ export function useThumbnailTagList() {
     onUpdateTag,
     onResetTags,
     onUpdateTagOrder,
+    onRandomShuffle,
   };
 }

--- a/src/components/thumbnail-maker/hooks/useThumbnailTagList.ts
+++ b/src/components/thumbnail-maker/hooks/useThumbnailTagList.ts
@@ -47,6 +47,7 @@ export function useThumbnailTagList() {
   };
 
   const onRandomShuffle = () => {
+    prevTags.current = tags;
     const newTags = getRandomTagStyles(tags);
     setTags(newTags);
   };

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -1,4 +1,4 @@
-import { Image, InfoIcon } from "lucide-react";
+import { Image, InfoIcon, Shuffle } from "lucide-react";
 import { Button } from "../ui/button";
 import { AddTagSection } from "./AddTagSection";
 import { CanvasContainer } from "./CanvasContainer";
@@ -15,6 +15,7 @@ import { Switch } from "../ui/switch";
 import { useState } from "react";
 import { Alert, AlertTitle, AlertDescription } from "../ui/alert";
 import { DragModeCanvas } from "./DragMode/DragModeCanvas";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 function ThumbnailMaker() {
   const [isDragMode, setIsDragMode] = useState(false);
@@ -22,7 +23,13 @@ function ThumbnailMaker() {
   const { tagsContainerRef, checkOverflow, showOverflowToast } =
     useCheckTagOverflow();
 
-  const { onAddTag, onRemoveTag, onRollbackTags, onUpdateTag } = useTagAction();
+  const {
+    onAddTag,
+    onRemoveTag,
+    onRollbackTags,
+    onUpdateTag,
+    onRandomShuffle,
+  } = useTagAction();
 
   const { onSelectTag, clearSelectedTag } = useSelectedTagAction();
 
@@ -69,6 +76,21 @@ function ThumbnailMaker() {
       <div className="flex items-center justify-end gap-2">
         <Switch checked={isDragMode} onCheckedChange={setIsDragMode} />
         <p>{isDragMode ? "Drag Mode" : "Default Mode"}</p>
+
+        <Tooltip>
+          <TooltipTrigger>
+            <Button variant="outline" onClick={onRandomShuffle} className="p-3">
+              <Shuffle color="#fff" size={20} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[200px]">
+            <p className="text-sm font-medium">Random Shuffle</p>
+            <p className="text-xs text-muted-foreground">
+              Randomly changes the style of the tag. It's useful if you want to
+              make a thumbnail easily.
+            </p>
+          </TooltipContent>
+        </Tooltip>
       </div>
       {isDragMode ? (
         <DragModeCanvas

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -77,14 +77,14 @@ function ThumbnailMaker() {
         <Switch checked={isDragMode} onCheckedChange={setIsDragMode} />
         <p>{isDragMode ? "Drag Mode" : "Default Mode"}</p>
 
-        <Tooltip>
+        <Tooltip defaultOpen>
           <TooltipTrigger>
             <Button variant="outline" onClick={onRandomShuffle} className="p-3">
               <Shuffle color="#fff" size={20} />
             </Button>
           </TooltipTrigger>
           <TooltipContent className="max-w-[200px]">
-            <p className="text-sm font-medium">Random Shuffle</p>
+            <p className="text-sm font-medium">Random Shuffle Open 🎉</p>
             <p className="text-xs text-muted-foreground">
               Randomly changes the style of the tag. It's useful if you want to
               make a thumbnail easily.


### PR DESCRIPTION
## 🎯 Changes

태그 스타일 랜덤 기능을 추가했습니다:
- 개별 태그에 대해 Filled/Outlined/Ghost + Round/Square 조합 중 랜덤 선택
- 전체 태그에 대한 일괄 랜덤 스타일 적용 기능

## 🌟 Background

사용자 피드백을 통해 다음과 같은 니즈를 확인했습니다:
- 태그별 스타일 선택에 많은 시간과 고민이 필요한 사용자들이 있음
- 랜덤 기능을 통해 여러 스타일을 빠르게 시도해보고 마음에 드는 조합을 선택하고 싶은 니즈가 있음

![스크린샷 2025-02-13 오후 6 31 36](https://github.com/user-attachments/assets/88798fc9-3928-4628-b12b-1dc8b3160350)

## 📝 Implementation Details

- 태그 스타일 조합: 
  - 스타일: Filled, Outlined, Ghost
  - 모양: Round, Square
  - 총 6가지 조합 중 랜덤 선택


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 썸네일 제작 도구에 태그의 무작위 스타일 셔플 기능이 추가되어, 버튼 클릭 시 태그 스타일이 다양하게 변경됩니다.
  - 다양한 태그 스타일 조합 옵션이 도입되어, 사용자 인터페이스에서 더 풍부한 디자인 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->