### PR TITLE
Canvas 레이아웃 조정

### DIFF
--- a/src/components/thumbnail-maker/CanvasContainer.tsx
+++ b/src/components/thumbnail-maker/CanvasContainer.tsx
@@ -1,6 +1,6 @@
 import { cn } from "src/lib/utils";
-import { canvasSize } from "./assets/constants";
 import { useCurrentPaletteStyle } from "./Palette.context";
+import { useCanvasSize } from "./CanvasSize.context";
 
 interface Props {
   previewRef: React.RefObject<HTMLDivElement>;
@@ -14,21 +14,27 @@ export function CanvasContainer({
   children,
 }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
+  const { canvasStyle } = useCanvasSize();
+
+  const bg = paletteStyle.background.includes("url")
+    ? { backgroundImage: paletteStyle.background }
+    : { background: paletteStyle.background };
+
   return (
     <div className="max-h-full w-[768px] overflow-hidden rounded-lg">
       <div
         ref={previewRef}
         key={paletteStyle.background}
         style={{
-          background: paletteStyle.background,
-          aspectRatio: canvasSize.aspectRatio,
-          padding: canvasSize.padding,
+          ...bg,
+          aspectRatio: canvasStyle.aspectRatio,
+          padding: canvasStyle.padding,
         }}
         className={cn("bg-cover bg-center bg-no-repeat")}
       >
         <div
           ref={tagsContainerRef}
-          style={{ gap: canvasSize.gap }}
+          style={{ gap: canvasStyle.gap }}
           className="flex h-full flex-wrap content-start"
         >
           {children}

--- a/src/components/thumbnail-maker/CanvasContainer.tsx
+++ b/src/components/thumbnail-maker/CanvasContainer.tsx
@@ -1,6 +1,7 @@
 import { cn } from "src/lib/utils";
 import { useCurrentPaletteStyle } from "./Palette.context";
 import { useCanvasSize } from "./CanvasSize.context";
+import { TAG_ALIGNMENT_VALUES, useTagStyle } from "./Tag.context";
 
 interface Props {
   previewRef: React.RefObject<HTMLDivElement>;
@@ -15,6 +16,7 @@ export function CanvasContainer({
 }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
   const { canvasStyle } = useCanvasSize();
+  const { alignment } = useTagStyle();
 
   const bg = paletteStyle.background.includes("url")
     ? { backgroundImage: paletteStyle.background }
@@ -34,7 +36,7 @@ export function CanvasContainer({
       >
         <div
           ref={tagsContainerRef}
-          style={{ gap: canvasStyle.gap }}
+          style={{ gap: canvasStyle.gap, ...TAG_ALIGNMENT_VALUES[alignment] }}
           className="flex h-full flex-wrap content-start"
         >
           {children}

--- a/src/components/thumbnail-maker/CanvasSize.context.tsx
+++ b/src/components/thumbnail-maker/CanvasSize.context.tsx
@@ -1,0 +1,67 @@
+import { createContext, PropsWithChildren, useContext } from "react";
+import useStorageState from "use-storage-state";
+import {
+  CANVAS_SIZE_STORAGE_KEY,
+  CanvasSizePreset,
+  canvasSizePresets,
+} from "./assets/constants";
+
+interface CanvasSizeContextType {
+  currentSize: CanvasSizePreset;
+  canvasStyle: (typeof canvasSizePresets)[CanvasSizePreset];
+}
+
+interface CanvasSizeActionContextType {
+  onSizeChange: (size: CanvasSizePreset) => void;
+}
+
+const CanvasSizeContext = createContext<CanvasSizeContextType | undefined>(
+  undefined
+);
+const CanvasSizeActionContext = createContext<
+  CanvasSizeActionContextType | undefined
+>(undefined);
+
+export function CanvasSizeProvider({ children }: PropsWithChildren) {
+  const [currentSize, setCurrentSize] = useStorageState<CanvasSizePreset>(
+    CANVAS_SIZE_STORAGE_KEY,
+    {
+      defaultValue: "wide",
+    }
+  );
+
+  const value = {
+    currentSize,
+    canvasStyle: canvasSizePresets[currentSize],
+  };
+
+  const actions = {
+    onSizeChange: (size: CanvasSizePreset) => setCurrentSize(size),
+  };
+
+  return (
+    <CanvasSizeContext.Provider value={value}>
+      <CanvasSizeActionContext.Provider value={actions}>
+        {children}
+      </CanvasSizeActionContext.Provider>
+    </CanvasSizeContext.Provider>
+  );
+}
+
+export const useCanvasSize = () => {
+  const context = useContext(CanvasSizeContext);
+  if (context === undefined) {
+    throw new Error("useCanvasSize must be used within a CanvasSizeProvider");
+  }
+  return context;
+};
+
+export const useCanvasSizeAction = () => {
+  const context = useContext(CanvasSizeActionContext);
+  if (context === undefined) {
+    throw new Error(
+      "useCanvasSizeAction must be used within a CanvasSizeProvider"
+    );
+  }
+  return context;
+};

--- a/src/components/thumbnail-maker/DragMode/DragModeCanvas.tsx
+++ b/src/components/thumbnail-maker/DragMode/DragModeCanvas.tsx
@@ -14,11 +14,11 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { cn } from "src/lib/utils";
-import { canvasSize } from "../assets/constants";
 import { useCurrentPaletteStyle } from "../Palette.context";
 import { SortableTagItem } from "./SortableTagItem";
 import { useTagAction, useTagList } from "../Tag.context";
 import { TagItem } from "../TagItem";
+import { useCanvasSize } from "../CanvasSize.context";
 
 interface Props {
   previewRef: React.RefObject<HTMLDivElement>;
@@ -27,6 +27,7 @@ interface Props {
 
 export function DragModeCanvas({ previewRef, tagsContainerRef }: Props) {
   const paletteStyle = useCurrentPaletteStyle();
+  const { canvasStyle: canvasSize } = useCanvasSize();
 
   const { tags } = useTagList();
   const { onUpdateTagOrder } = useTagAction();

--- a/src/components/thumbnail-maker/DragMode/DragModeCanvas.tsx
+++ b/src/components/thumbnail-maker/DragMode/DragModeCanvas.tsx
@@ -16,7 +16,12 @@ import {
 import { cn } from "src/lib/utils";
 import { useCurrentPaletteStyle } from "../Palette.context";
 import { SortableTagItem } from "./SortableTagItem";
-import { useTagAction, useTagList } from "../Tag.context";
+import {
+  TAG_ALIGNMENT_VALUES,
+  useTagAction,
+  useTagList,
+  useTagStyle,
+} from "../Tag.context";
 import { TagItem } from "../TagItem";
 import { useCanvasSize } from "../CanvasSize.context";
 
@@ -31,6 +36,7 @@ export function DragModeCanvas({ previewRef, tagsContainerRef }: Props) {
 
   const { tags } = useTagList();
   const { onUpdateTagOrder } = useTagAction();
+  const { alignment } = useTagStyle();
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -73,8 +79,11 @@ export function DragModeCanvas({ previewRef, tagsContainerRef }: Props) {
         >
           <div
             ref={tagsContainerRef}
-            style={{ gap: canvasSize.gap }}
-            className="flex h-full flex-wrap content-start"
+            style={{
+              gap: canvasSize.gap,
+              ...TAG_ALIGNMENT_VALUES[alignment],
+            }}
+            className="flex h-full flex-wrap "
           >
             <SortableContext
               items={tags.map((tag) => tag.id)}

--- a/src/components/thumbnail-maker/MenuBar.tsx
+++ b/src/components/thumbnail-maker/MenuBar.tsx
@@ -25,6 +25,7 @@ import {
 } from "../ui/dropdown-menu";
 import { useCanvasSize, useCanvasSizeAction } from "./CanvasSize.context";
 import { CanvasSizePreset, canvasSizePresets } from "./assets/constants";
+import { AlignmentMenu } from "./SubMenu/AlignmentMenu";
 
 const canvasSizeLabels: Record<CanvasSizePreset, string> = {
   wide: "Wide (1080 x 565)",
@@ -47,6 +48,7 @@ export function MenuBar({
       <TemplateMenu downloadImage={downloadImage} getImageFile={getImageFile} />
       <CanvasMenu isDragMode={isDragMode} setIsDragMode={setIsDragMode} />
       <CanvasSizeMenu />
+      <AlignmentMenu />
     </Menubar>
   );
 }

--- a/src/components/thumbnail-maker/MenuBar.tsx
+++ b/src/components/thumbnail-maker/MenuBar.tsx
@@ -16,6 +16,20 @@ import { SaveTemplateSheet } from "./SubMenu/SaveTemplateSheet";
 import { DownloadTemplateToLocalConfirm } from "./SubMenu/DownloadTemplateToLocalConfirm";
 import { ImportTemplateConfirm } from "./SubMenu/ImportTemplateConfirm";
 import { Link } from "react-router-dom";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { useCanvasSize, useCanvasSizeAction } from "./CanvasSize.context";
+import { CanvasSizePreset, canvasSizePresets } from "./assets/constants";
+
+const canvasSizeLabels: Record<CanvasSizePreset, string> = {
+  wide: "Wide (1080 x 565)",
+  square: "Square (1:1)",
+} as const;
 
 export function MenuBar({
   isDragMode,
@@ -32,6 +46,7 @@ export function MenuBar({
     <Menubar>
       <TemplateMenu downloadImage={downloadImage} getImageFile={getImageFile} />
       <CanvasMenu isDragMode={isDragMode} setIsDragMode={setIsDragMode} />
+      <CanvasSizeMenu />
     </Menubar>
   );
 }
@@ -129,5 +144,30 @@ function CanvasMenu({
         </MenubarItem>
       </MenubarContent>
     </MenubarMenu>
+  );
+}
+
+export function CanvasSizeMenu() {
+  const { currentSize } = useCanvasSize();
+  const { onSizeChange } = useCanvasSizeAction();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          {canvasSizeLabels[currentSize]}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {Object.keys(canvasSizePresets).map((size) => (
+          <DropdownMenuItem
+            key={size}
+            onClick={() => onSizeChange(size as CanvasSizePreset)}
+          >
+            {canvasSizeLabels[size as CanvasSizePreset]}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/thumbnail-maker/MenuBar.tsx
+++ b/src/components/thumbnail-maker/MenuBar.tsx
@@ -143,7 +143,7 @@ function CanvasMenu({
           <Shuffle color="#fff" size={16} /> Random Shuffle
           <MenubarShortcut>^R</MenubarShortcut>
         </MenubarItem>
-        <MenubarItem onClick={onRandomShuffle}>
+        <MenubarItem>
           <AlignmentMenu />
         </MenubarItem>
       </MenubarContent>

--- a/src/components/thumbnail-maker/MenuBar.tsx
+++ b/src/components/thumbnail-maker/MenuBar.tsx
@@ -48,7 +48,6 @@ export function MenuBar({
       <TemplateMenu downloadImage={downloadImage} getImageFile={getImageFile} />
       <CanvasMenu isDragMode={isDragMode} setIsDragMode={setIsDragMode} />
       <CanvasSizeMenu />
-      <AlignmentMenu />
     </Menubar>
   );
 }
@@ -143,6 +142,9 @@ function CanvasMenu({
         <MenubarItem onClick={onRandomShuffle}>
           <Shuffle color="#fff" size={16} /> Random Shuffle
           <MenubarShortcut>^R</MenubarShortcut>
+        </MenubarItem>
+        <MenubarItem onClick={onRandomShuffle}>
+          <AlignmentMenu />
         </MenubarItem>
       </MenubarContent>
     </MenubarMenu>

--- a/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
+++ b/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
@@ -15,8 +15,8 @@ export const AlignmentMenu = () => {
       <h3 className="text-sm font-medium">태그 정렬</h3>
       <div className="flex gap-2">
         <button
-          className={`p-2 rounded ${
-            alignment === "start" ? "bg-blue-100" : "bg-gray-100"
+          className={`p-2 rounded border ${
+            alignment === "start" ? "border border-gray-100" : "border-gray-50 "
           }`}
           onClick={() => handleAlignmentChange("start")}
           title="좌측 정렬"
@@ -24,8 +24,10 @@ export const AlignmentMenu = () => {
           <AlignLeftIcon size={16} />
         </button>
         <button
-          className={`p-2 rounded ${
-            alignment === "center" ? "bg-blue-100" : "bg-gray-100"
+          className={`p-2 rounded border ${
+            alignment === "center"
+              ? "border border-gray-100"
+              : "border-gray-50 "
           }`}
           onClick={() => handleAlignmentChange("center")}
           title="중앙 정렬"
@@ -33,8 +35,8 @@ export const AlignmentMenu = () => {
           <AlignCenterIcon size={16} />
         </button>
         <button
-          className={`p-2 rounded ${
-            alignment === "end" ? "bg-blue-100" : "bg-gray-100"
+          className={`p-2 rounded border ${
+            alignment === "end" ? "border border-gray-100" : "border-gray-50 "
           }`}
           onClick={() => handleAlignmentChange("end")}
           title="우측 정렬"

--- a/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
+++ b/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { TagAlignment, useTagStyle, useTagStyleAction } from "../Tag.context";
+import { AlignLeftIcon, AlignCenterIcon, AlignRightIcon } from "lucide-react"; // 아이콘은 필요에 따라 변경하세요
+
+export const AlignmentMenu = () => {
+  const { alignment } = useTagStyle();
+  const { setAlignment } = useTagStyleAction();
+
+  const handleAlignmentChange = (newAlignment: TagAlignment) => {
+    setAlignment(newAlignment);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm font-medium">태그 정렬</h3>
+      <div className="flex gap-2">
+        <button
+          className={`p-2 rounded ${
+            alignment === "start" ? "bg-blue-100" : "bg-gray-100"
+          }`}
+          onClick={() => handleAlignmentChange("start")}
+          title="좌측 정렬"
+        >
+          <AlignLeftIcon size={16} />
+        </button>
+        <button
+          className={`p-2 rounded ${
+            alignment === "center" ? "bg-blue-100" : "bg-gray-100"
+          }`}
+          onClick={() => handleAlignmentChange("center")}
+          title="중앙 정렬"
+        >
+          <AlignCenterIcon size={16} />
+        </button>
+        <button
+          className={`p-2 rounded ${
+            alignment === "end" ? "bg-blue-100" : "bg-gray-100"
+          }`}
+          onClick={() => handleAlignmentChange("end")}
+          title="우측 정렬"
+        >
+          <AlignRightIcon size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/thumbnail-maker/Tag.context.tsx
+++ b/src/components/thumbnail-maker/Tag.context.tsx
@@ -1,6 +1,33 @@
-import { createContext, PropsWithChildren, useContext, useState } from "react";
+import {
+  createContext,
+  CSSProperties,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from "react";
 import { Tag } from "./assets/palette.types";
 import { useThumbnailTagList } from "./hooks/useThumbnailTagList";
+
+// 태그 정렬 타입 정의
+export type TagAlignment = "start" | "center" | "end";
+
+export const TAG_ALIGNMENT_VALUES: Record<TagAlignment, CSSProperties> = {
+  start: {
+    justifyContent: "flex-start",
+    alignItems: "flex-start",
+    alignContent: "flex-start",
+  },
+  center: {
+    justifyContent: "center",
+    alignItems: "center",
+    alignContent: "center",
+  },
+  end: {
+    justifyContent: "flex-end",
+    alignItems: "flex-end",
+    alignContent: "flex-end",
+  },
+};
 
 interface TagListContextType {
   tags: Tag[];
@@ -13,8 +40,16 @@ interface TagActionContextType {
   onResetTags: () => void;
   onRollbackTags: () => void;
   onUpdateTagOrder: (newTags: Tag[]) => void;
-
   onRandomShuffle: () => void;
+}
+
+// 태그 스타일 컨텍스트 추가
+interface TagStyleContextType {
+  alignment: TagAlignment;
+}
+
+interface TagStyleActionContextType {
+  setAlignment: (alignment: TagAlignment) => void;
 }
 
 const TagListContext = createContext<TagListContextType | undefined>({
@@ -28,6 +63,17 @@ const TagActionContext = createContext<TagActionContextType | undefined>({
   onRollbackTags: () => {},
   onUpdateTagOrder: () => {},
   onRandomShuffle: () => {},
+});
+
+// 새로운 스타일 컨텍스트 생성
+const TagStyleContext = createContext<TagStyleContextType | undefined>({
+  alignment: "start",
+});
+
+const TagStyleActionContext = createContext<
+  TagStyleActionContextType | undefined
+>({
+  setAlignment: () => {},
 });
 
 interface SelectTagContextType {
@@ -62,6 +108,8 @@ export const TagProvider = ({ children }: PropsWithChildren) => {
   } = useThumbnailTagList();
 
   const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
+  // 태그 정렬 상태 추가
+  const [alignment, setAlignment] = useState<TagAlignment>("start");
 
   const onSelectTag = (tag: Tag) => {
     setSelectedTag(tag);
@@ -88,7 +136,11 @@ export const TagProvider = ({ children }: PropsWithChildren) => {
           <SelectTagActionContext.Provider
             value={{ onSelectTag, clearSelectedTag }}
           >
-            {children}
+            <TagStyleContext.Provider value={{ alignment }}>
+              <TagStyleActionContext.Provider value={{ setAlignment }}>
+                {children}
+              </TagStyleActionContext.Provider>
+            </TagStyleContext.Provider>
           </SelectTagActionContext.Provider>
         </SelectedTagContext.Provider>
       </TagActionContext.Provider>
@@ -124,6 +176,23 @@ export const useTagAction = () => {
   const context = useContext(TagActionContext);
   if (context === undefined) {
     throw new Error("useTagAction must be used within a TagProvider");
+  }
+  return context;
+};
+
+// 새로운 훅 추가
+export const useTagStyle = () => {
+  const context = useContext(TagStyleContext);
+  if (context === undefined) {
+    throw new Error("useTagStyle must be used within a TagProvider");
+  }
+  return context;
+};
+
+export const useTagStyleAction = () => {
+  const context = useContext(TagStyleActionContext);
+  if (context === undefined) {
+    throw new Error("useTagStyleAction must be used within a TagProvider");
   }
   return context;
 };

--- a/src/components/thumbnail-maker/assets/constants.ts
+++ b/src/components/thumbnail-maker/assets/constants.ts
@@ -1,8 +1,26 @@
-export const canvasSize = {
-  aspectRatio: 1080 / 565,
-  padding: "40px 50px",
-  gap: "16px 8px",
+export type CanvasSizePreset = "wide" | "square";
+
+export const canvasSizePresets: Record<
+  CanvasSizePreset,
+  {
+    aspectRatio: number;
+    padding: string;
+    gap: string;
+  }
+> = {
+  wide: {
+    aspectRatio: 1080 / 565,
+    padding: "40px 50px",
+    gap: "16px 8px",
+  },
+  square: {
+    aspectRatio: 1,
+    padding: "40px",
+    gap: "16px 8px",
+  },
 } as const;
+
+export const CANVAS_SIZE_STORAGE_KEY = "@thumbnail-maker/canvas-size";
 
 export const THUMBNAIL_MAKER_STORAGE_KEY = "@thumbnail-maker/tags";
 export const THUMBNAIL_MAKERS_PALETTE_STORAGE_KEY = "@thumbnail-maker/palette";

--- a/src/components/thumbnail-maker/assets/palette.constants.ts
+++ b/src/components/thumbnail-maker/assets/palette.constants.ts
@@ -19,8 +19,7 @@ export const TAG_STYLE_COMBINATIONS: {
 
 export const PALETTE: Record<PaletteVariant, PaletteStyle> = {
   blue_gradient: {
-    background:
-      "no-repeat center/100% url(/assets/palette/thumbnail-blue-gradient-bg.webp)",
+    background: "url(/assets/palette/thumbnail-blue-gradient-bg.webp)",
     paletteBackground:
       "linear-gradient(127deg, #8ECDF2 3.2%, #A0C8FC 21.06%, #A4C7FE 30.47%, #96BDFE 38.93%, #84B0FE 47.86%, #2B6FFF 97.22%)",
     tagStyle: {
@@ -48,8 +47,7 @@ export const PALETTE: Record<PaletteVariant, PaletteStyle> = {
     },
   },
   rose_gradient: {
-    background:
-      "no-repeat center/100% url(/assets/palette/thumbnail-rose-gradient-bg.webp)",
+    background: "url(/assets/palette/thumbnail-rose-gradient-bg.webp)",
     paletteBackground:
       "linear-gradient(115deg, #FDD4D5 0%, #EDB8D1 27.5%, #AFB6E4 70.5%, #92B5ED 100%)",
     tagStyle: {

--- a/src/components/thumbnail-maker/index.tsx
+++ b/src/components/thumbnail-maker/index.tsx
@@ -17,6 +17,8 @@ import { Alert, AlertTitle, AlertDescription } from "../ui/alert";
 import { DragModeCanvas } from "./DragMode/DragModeCanvas";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { MenuBar } from "./MenuBar";
+import { CanvasSizeProvider } from "./CanvasSize.context";
+import { PaletteProvider } from "./Palette.context";
 
 function ThumbnailMaker() {
   const [isDragMode, setIsDragMode] = useState(false);
@@ -67,65 +69,69 @@ function ThumbnailMaker() {
   };
 
   return (
-    <div className="mx-auto flex max-w-[768px] flex-col gap-4 py-8">
-      <h1 className="mb-7 text-center text-[60px] text-[#C1CCFF]">
-        Thumbnail Maker
-      </h1>
-      <MenuBar
-        isDragMode={isDragMode}
-        setIsDragMode={setIsDragMode}
-        getImageFile={getImageFile}
-        downloadImage={downloadImage}
-      />
+    <PaletteProvider>
+      <CanvasSizeProvider>
+        <div className="mx-auto flex max-w-[768px] flex-col gap-4 py-8">
+          <h1 className="mb-7 text-center text-[60px] text-[#C1CCFF]">
+            Thumbnail Maker
+          </h1>
+          <MenuBar
+            isDragMode={isDragMode}
+            setIsDragMode={setIsDragMode}
+            getImageFile={getImageFile}
+            downloadImage={downloadImage}
+          />
 
-      <AddTagSection onAction={handleAddTag} />
+          <AddTagSection onAction={handleAddTag} />
 
-      {isDragMode ? (
-        <DragModeCanvas
-          previewRef={previewRef}
-          tagsContainerRef={tagsContainerRef}
-        />
-      ) : (
-        <CanvasContainer
-          previewRef={previewRef}
-          tagsContainerRef={tagsContainerRef}
-        >
-          <TagList setOpenTagSheet={onSelectTag} />
-        </CanvasContainer>
-      )}
-      <TagChangeSheet
-        onStyleChange={handleChangeTag}
-        onRemove={handleRemoveTag}
-      />
-      <TagEmojiSheet
-        onStyleChange={handleChangeTag}
-        onRemove={handleRemoveTag}
-      />
-      <div className="flex items-center justify-between">
-        <PalettePicker />
-        <SubActionMenu
-          getImageFile={getImageFile}
-          downloadImage={downloadImage}
-        />
-      </div>
-      <Alert variant="outline" className="mt-8">
-        <InfoIcon className="mt-0 h-4 w-4" />
-        <div>
-          <AlertTitle>
-            Thank you everyone for using Thumbnail Maker 😄
-          </AlertTitle>
-          <AlertDescription>
-            - Please provide sources when using thumbnails on your blog
-            <br />- Your valuable input helps us create a better service for
-            everyone [
-            <a href="https://github.com/sumi-0011/Thumbnail-Maker/issues/new">
-              feedback form
-            </a>
-            ]
-          </AlertDescription>
+          {isDragMode ? (
+            <DragModeCanvas
+              previewRef={previewRef}
+              tagsContainerRef={tagsContainerRef}
+            />
+          ) : (
+            <CanvasContainer
+              previewRef={previewRef}
+              tagsContainerRef={tagsContainerRef}
+            >
+              <TagList setOpenTagSheet={onSelectTag} />
+            </CanvasContainer>
+          )}
+          <TagChangeSheet
+            onStyleChange={handleChangeTag}
+            onRemove={handleRemoveTag}
+          />
+          <TagEmojiSheet
+            onStyleChange={handleChangeTag}
+            onRemove={handleRemoveTag}
+          />
+          <div className="flex items-center justify-between">
+            <PalettePicker />
+            <SubActionMenu
+              getImageFile={getImageFile}
+              downloadImage={downloadImage}
+            />
+          </div>
+          <Alert variant="outline" className="mt-8">
+            <InfoIcon className="mt-0 h-4 w-4" />
+            <div>
+              <AlertTitle>
+                Thank you everyone for using Thumbnail Maker 😄
+              </AlertTitle>
+              <AlertDescription>
+                - Please provide sources when using thumbnails on your blog
+                <br />- Your valuable input helps us create a better service for
+                everyone [
+                <a href="https://github.com/sumi-0011/Thumbnail-Maker/issues/new">
+                  feedback form
+                </a>
+                ]
+              </AlertDescription>
+            </div>
+          </Alert>
         </div>
-      </Alert>
-    </div>
+      </CanvasSizeProvider>
+    </PaletteProvider>
   );
 }
 


### PR DESCRIPTION
- 티스토리 등의 블로그 서비스의 1:1 썸네일을 지원하기 위해 캔버스 사이즈를 선택할 수 있는 기능 추가
- tag 리스트의 위치를 조정할 수 있는 레이아웃 옵션 추가 (ex, 중앙 정렬

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 메뉴바에 캔버스 사이즈 선택 드롭다운과 태그 정렬 옵션 버튼이 추가되어 사용자가 인터페이스를 보다 쉽게 조정할 수 있습니다.
- **Refactor**
  - 캔버스 및 태그 스타일링 로직이 개선되어 레이아웃이 보다 유연하고 반응형으로 동작합니다.
- **Style**
  - 배경 이미지 적용 방식이 단순화되어 깔끔한 비주얼 효과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->