### PR TITLE
feat: AddBlogExampleSheet 디자인 개선 및 갤러리 페이지 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-menubar": "^1.1.2",
     "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "i18next-resources-for-ts": "i18next-resources-for-ts toc -i ./src/i18n/locales/en -o ./src/types/resources.ts",
     "translate": "transmart",
     "scripts": "node scripts/emoji.js",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -73,6 +75,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.5.1",
     "@commitlint/config-conventional": "^17.4.4",
+    "@playwright/test": "^1.58.2",
     "@tanstack/react-query-devtools": "^4.29.1",
     "@types/file-saver": "^2.0.7",
     "@types/loadable__component": "^5.13.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:5000",
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:5000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.2.10
+        version: 1.2.10(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-select':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -942,11 +945,17 @@ packages:
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
   '@radix-ui/react-alert-dialog@1.1.4':
     resolution: {integrity: sha512-A6Kh23qZDLy3PSU4bh2UJZznOrUdHImIXqF8YtUa6CN73f8EOO9XlXSCd9IHyPvIquTaa/kwaSWzZTtUvgXVGw==}
@@ -1044,6 +1053,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.0':
     resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
     peerDependencies:
@@ -1055,6 +1073,15 @@ packages:
 
   '@radix-ui/react-context@1.1.1':
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1077,6 +1104,15 @@ packages:
 
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1310,6 +1346,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
@@ -1336,6 +1385,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.0':
     resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
     peerDependencies:
@@ -1351,6 +1413,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.1':
     resolution: {integrity: sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1399,6 +1474,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1480,6 +1564,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.1.0':
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
@@ -1500,6 +1593,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5546,9 +5648,13 @@ snapshots:
 
   '@radix-ui/number@1.1.0': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.0': {}
 
   '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-alert-dialog@1.1.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5634,6 +5740,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
   '@radix-ui/react-context@1.1.0(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -5641,6 +5753,12 @@ snapshots:
       '@types/react': 18.3.10
 
   '@radix-ui/react-context@1.1.1(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -5669,6 +5787,12 @@ snapshots:
       '@types/react-dom': 18.3.0
 
   '@radix-ui/react-direction@1.1.0(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -5928,6 +6052,16 @@ snapshots:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.10)(react@18.3.1)
@@ -5940,6 +6074,15 @@ snapshots:
   '@radix-ui/react-primitive@2.0.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -5974,6 +6117,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -6028,6 +6188,13 @@ snapshots:
   '@radix-ui/react-slot@1.1.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -6120,6 +6287,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
   '@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
@@ -6135,6 +6308,12 @@ snapshots:
       '@types/react': 18.3.10
 
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^17.4.4
         version: 17.8.1
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tanstack/react-query-devtools':
         specifier: ^4.29.1
         version: 4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -941,6 +944,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -2878,6 +2886,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3810,6 +3823,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -5645,6 +5668,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@radix-ui/number@1.1.0': {}
 
@@ -7794,6 +7821,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8714,6 +8744,14 @@ snapshots:
     optional: true
 
   pirates@4.0.6: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -92,7 +92,7 @@ function ImageSection({ image, alt, variant }: ImageSectionProps) {
         <img
           src={image}
           alt={alt}
-          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+          className="w-full h-full object-cover group-hover:scale-[101%] transition-transform duration-300"
           draggable={false}
         />
       ) : (

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -6,6 +6,7 @@ import {
   LucideIcon,
 } from "lucide-react";
 import { PaletteVariant } from "../thumbnail-maker/assets/palette.types";
+import { getDisplayImageAndTitle } from "../template-gallery/templateUtils";
 
 export type TemplateType = "blog_only" | "full_with_blog" | "template_only";
 
@@ -223,12 +224,10 @@ function GalleryCard({ template, variant, onClick }: GalleryCardProps) {
   const styles = variantStyles[variant];
 
   // blog variant는 블로그 데이터 우선 사용
-  const displayImage =
+  const { displayImage, displayTitle } =
     variant === "blog"
-      ? template.blog_image || template.thumbnail
-      : template.thumbnail;
-  const displayTitle =
-    variant === "blog" ? template.blog_title || template.title : template.title;
+      ? getDisplayImageAndTitle(template)
+      : { displayImage: template.thumbnail, displayTitle: template.title };
   const displayDescription =
     variant === "blog"
       ? template.blog_description || template.description

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -1,6 +1,7 @@
-import { ArrowRightIcon } from "lucide-react";
-import { cn } from "src/lib/utils";
-import { PaletteVariant, Tag } from "../thumbnail-maker/assets/palette.types";
+import { ArrowRightIcon, ExternalLink, User, Sparkles, LucideIcon } from "lucide-react";
+import { PaletteVariant } from "../thumbnail-maker/assets/palette.types";
+
+export type TemplateType = "blog_only" | "full_with_blog" | "template_only";
 
 export type Template = {
   id: number;
@@ -13,8 +14,242 @@ export type Template = {
       type: PaletteVariant | string;
     };
     tags: string;
-  };
+  } | null;
+  // 블로그 연동 필드
+  template_type?: TemplateType;
+  blog_url?: string;
+  blog_title?: string;
+  blog_description?: string;
+  blog_image?: string;
+  author_name?: string;
 };
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+type CardVariant = "blog" | "template";
+
+const variantStyles = {
+  blog: {
+    border: "border-purple-500/30",
+    hoverBorder: "hover:border-purple-500/50",
+    bg: "from-purple-900/10",
+    shadow: "hover:shadow-purple-500/10",
+    badge: "bg-purple-500/20 text-purple-400",
+    action: "text-purple-400 group-hover:text-purple-300",
+    fallbackGradient: "from-purple-500/20 to-pink-500/20",
+    fallbackEmoji: "📝",
+  },
+  template: {
+    border: "border-emerald-500/30",
+    hoverBorder: "hover:border-emerald-500/50",
+    bg: "from-emerald-900/10",
+    shadow: "hover:shadow-emerald-500/10",
+    badge: "bg-emerald-500/20 text-emerald-400",
+    action: "text-emerald-400 group-hover:text-emerald-300",
+    fallbackGradient: "from-emerald-500/20 to-teal-500/20",
+    fallbackEmoji: "🎨",
+  },
+} as const;
+
+const variantConfig: Record<
+  CardVariant,
+  {
+    badgeIcon: LucideIcon;
+    badgeText: string;
+    defaultDescription: string;
+  }
+> = {
+  blog: {
+    badgeIcon: ExternalLink,
+    badgeText: "Blog",
+    defaultDescription: "블로그에서 이 썸네일이 사용되었습니다",
+  },
+  template: {
+    badgeIcon: Sparkles,
+    badgeText: "Template",
+    defaultDescription: "이 템플릿을 사용해보세요",
+  },
+};
+
+// ============================================================================
+// Sub Components
+// ============================================================================
+
+interface ImageSectionProps {
+  image: string | undefined;
+  alt: string;
+  variant: CardVariant;
+}
+
+function ImageSection({ image, alt, variant }: ImageSectionProps) {
+  const styles = variantStyles[variant];
+
+  return (
+    <div className="relative aspect-video overflow-hidden">
+      {image ? (
+        <img
+          src={image}
+          alt={alt}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+          draggable={false}
+        />
+      ) : (
+        <div
+          className={`w-full h-full bg-gradient-to-br ${styles.fallbackGradient} flex items-center justify-center`}
+        >
+          <span className="text-4xl">{styles.fallbackEmoji}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface BadgeProps {
+  variant: CardVariant;
+}
+
+function Badge({ variant }: BadgeProps) {
+  const styles = variantStyles[variant];
+  const config = variantConfig[variant];
+  const Icon = config.badgeIcon;
+
+  return (
+    <p
+      className={`shrink-0 inline-flex items-center gap-1 px-2 py-0.5 ${styles.badge} rounded-full text-[10px] font-medium`}
+    >
+      <Icon className="w-2.5 h-2.5" />
+      {config.badgeText}
+    </p>
+  );
+}
+
+interface ContentSectionProps {
+  title: string;
+  description: string | undefined;
+  variant: CardVariant;
+}
+
+function ContentSection({ title, description, variant }: ContentSectionProps) {
+  const config = variantConfig[variant];
+
+  return (
+    <>
+      <Badge variant={variant} />
+      <div className="flex items-start gap-2">
+        <h3 className="text-sm font-semibold text-white line-clamp-1 flex-1">
+          {title}
+        </h3>
+      </div>
+      <p className="text-xs text-gray-400 line-clamp-2 min-h-[32px]">
+        {description || config.defaultDescription}
+      </p>
+    </>
+  );
+}
+
+interface FooterSectionProps {
+  template: Template;
+  variant: CardVariant;
+}
+
+function FooterSection({ template, variant }: FooterSectionProps) {
+  const styles = variantStyles[variant];
+  const hasLinkedBlog =
+    variant === "template" && template.template_type === "full_with_blog";
+
+  return (
+    <div className="flex items-center justify-between pt-2 border-t border-white/10">
+      {template.author_name ? (
+        <div className="flex items-center gap-1.5 text-gray-400">
+          <User className="w-3 h-3" />
+          <span className="text-xs">{template.author_name}</span>
+        </div>
+      ) : (
+        <div />
+      )}
+
+      {variant === "blog" ? (
+        <div
+          className={`flex items-center gap-1 ${styles.action} text-xs transition-colors`}
+        >
+          <span>View Blog</span>
+          <ExternalLink className="w-3 h-3" />
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          {hasLinkedBlog && template.blog_url && (
+            <a
+              href={template.blog_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center gap-1 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+            >
+              Blog
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+          <div
+            className={`flex items-center gap-1 ${styles.action} text-xs transition-colors`}
+          >
+            <ArrowRightIcon size={14} />
+            <span>Use</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+interface GalleryCardProps {
+  template: Template;
+  variant: CardVariant;
+  onClick: (template: Template) => void;
+}
+
+function GalleryCard({ template, variant, onClick }: GalleryCardProps) {
+  const styles = variantStyles[variant];
+
+  // blog variant는 블로그 데이터 우선 사용
+  const displayImage =
+    variant === "blog"
+      ? template.blog_image || template.thumbnail
+      : template.thumbnail;
+  const displayTitle =
+    variant === "blog" ? template.blog_title || template.title : template.title;
+  const displayDescription =
+    variant === "blog"
+      ? template.blog_description || template.description
+      : template.description;
+
+  return (
+    <div
+      className={`group cursor-pointer rounded-xl overflow-hidden border ${styles.border} bg-gradient-to-b ${styles.bg} to-background ${styles.hoverBorder} transition-all duration-300 hover:shadow-lg ${styles.shadow}`}
+      onClick={() => onClick(template)}
+    >
+      <ImageSection image={displayImage} alt={displayTitle} variant={variant} />
+
+      <div className="p-4 space-y-2">
+        <ContentSection
+          title={displayTitle}
+          description={displayDescription}
+          variant={variant}
+        />
+        <FooterSection template={template} variant={variant} />
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Export
+// ============================================================================
 
 interface GalleryItemProps {
   template: Template;
@@ -22,28 +257,11 @@ interface GalleryItemProps {
 }
 
 function GalleryItem({ template, onClick }: GalleryItemProps) {
+  const variant: CardVariant =
+    template.template_type === "blog_only" ? "blog" : "template";
+
   return (
-    <div
-      className="group relative cursor-pointer rounded-md overflow-hidden"
-      onClick={() => onClick(template)}
-    >
-      <div className="overflow-hidden rounded-md">
-        <img src={template.thumbnail} alt={template.title} draggable={false} />
-      </div>
-      {/* hover 했을떄 나타나기 */}
-      <div
-        className={cn(
-          "absolute left-0 top-0 h-full w-full bg-black/70 p-4 transition-all duration-300 ",
-          "flex items-end justify-end",
-          "hidden group-hover:flex"
-        )}
-      >
-        <button className="flex cursor-pointer items-center gap-2 text-base text-white hover:underline">
-          <ArrowRightIcon className="text-white" size={18} />
-          Using
-        </button>
-      </div>
-    </div>
+    <GalleryCard template={template} variant={variant} onClick={onClick} />
   );
 }
 

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -1,4 +1,10 @@
-import { ArrowRightIcon, ExternalLink, User, Sparkles, LucideIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  ExternalLink,
+  User,
+  Sparkles,
+  LucideIcon,
+} from "lucide-react";
 import { PaletteVariant } from "../thumbnail-maker/assets/palette.types";
 
 export type TemplateType = "blog_only" | "full_with_blog" | "template_only";
@@ -92,12 +98,12 @@ function ImageSection({ image, alt, variant }: ImageSectionProps) {
         <img
           src={image}
           alt={alt}
-          className="w-full h-full object-cover group-hover:scale-[101%] transition-transform duration-300"
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[101%]"
           draggable={false}
         />
       ) : (
         <div
-          className={`w-full h-full bg-gradient-to-br ${styles.fallbackGradient} flex items-center justify-center`}
+          className={`h-full w-full bg-gradient-to-br ${styles.fallbackGradient} flex items-center justify-center`}
         >
           <span className="text-4xl">{styles.fallbackEmoji}</span>
         </div>
@@ -117,9 +123,9 @@ function Badge({ variant }: BadgeProps) {
 
   return (
     <p
-      className={`shrink-0 inline-flex items-center gap-1 px-2 py-0.5 ${styles.badge} rounded-full text-[10px] font-medium`}
+      className={`inline-flex shrink-0 items-center gap-1 px-2 py-0.5 ${styles.badge} rounded-full text-[10px] font-medium`}
     >
-      <Icon className="w-2.5 h-2.5" />
+      <Icon className="h-2.5 w-2.5" />
       {config.badgeText}
     </p>
   );
@@ -138,11 +144,11 @@ function ContentSection({ title, description, variant }: ContentSectionProps) {
     <>
       <Badge variant={variant} />
       <div className="flex items-start gap-2">
-        <h3 className="text-sm font-semibold text-white line-clamp-1 flex-1">
+        <h3 className="line-clamp-1 flex-1 text-sm font-semibold text-white">
           {title}
         </h3>
       </div>
-      <p className="text-xs text-gray-400 line-clamp-2 min-h-[32px]">
+      <p className="line-clamp-2 min-h-[32px] text-xs text-gray-400">
         {description || config.defaultDescription}
       </p>
     </>
@@ -160,10 +166,10 @@ function FooterSection({ template, variant }: FooterSectionProps) {
     variant === "template" && template.template_type === "full_with_blog";
 
   return (
-    <div className="flex items-center justify-between pt-2 border-t border-white/10">
+    <div className="flex items-center justify-between border-t border-white/10 pt-2">
       {template.author_name ? (
         <div className="flex items-center gap-1.5 text-gray-400">
-          <User className="w-3 h-3" />
+          <User className="h-3 w-3" />
           <span className="text-xs">{template.author_name}</span>
         </div>
       ) : (
@@ -175,7 +181,7 @@ function FooterSection({ template, variant }: FooterSectionProps) {
           className={`flex items-center gap-1 ${styles.action} text-xs transition-colors`}
         >
           <span>View Blog</span>
-          <ExternalLink className="w-3 h-3" />
+          <ExternalLink className="h-3 w-3" />
         </div>
       ) : (
         <div className="flex items-center gap-2">
@@ -185,10 +191,10 @@ function FooterSection({ template, variant }: FooterSectionProps) {
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
-              className="flex items-center gap-1 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+              className="flex items-center gap-1 text-xs text-purple-400 transition-colors hover:text-purple-300"
             >
               Blog
-              <ExternalLink className="w-3 h-3" />
+              <ExternalLink className="h-3 w-3" />
             </a>
           )}
           <div
@@ -230,12 +236,12 @@ function GalleryCard({ template, variant, onClick }: GalleryCardProps) {
 
   return (
     <div
-      className={`group cursor-pointer rounded-xl overflow-hidden border ${styles.border} bg-gradient-to-b ${styles.bg} to-background ${styles.hoverBorder} transition-all duration-300 hover:shadow-lg ${styles.shadow}`}
+      className={`group cursor-pointer overflow-hidden rounded-xl border ${styles.border} bg-gradient-to-b ${styles.bg} to-background ${styles.hoverBorder} transition-all duration-300 hover:shadow-lg ${styles.shadow}`}
       onClick={() => onClick(template)}
     >
       <ImageSection image={displayImage} alt={displayTitle} variant={variant} />
 
-      <div className="p-4 space-y-2">
+      <div className="space-y-2 p-4">
         <ContentSection
           title={displayTitle}
           description={displayDescription}

--- a/src/components/landing/FullPageContext.tsx
+++ b/src/components/landing/FullPageContext.tsx
@@ -46,6 +46,13 @@ export function FullPageProvider({ children }: PropsWithChildren) {
     const index = sectionMappingRef.current[id];
     if (index !== undefined && scrollHandlerRef.current) {
       scrollHandlerRef.current(index);
+      return;
+    }
+
+    // Fallback: 일반 스크롤 모드에서 직접 DOM 요소로 스크롤
+    const element = document.querySelector(`[data-section="${id}"]`);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   }, []);
 
@@ -86,6 +93,13 @@ export function useScrollToSectionStandalone() {
       const index = globalSectionMapping[id];
       if (index !== undefined && globalScrollHandler) {
         globalScrollHandler(index);
+        return;
+      }
+
+      // Fallback: 일반 스크롤 모드에서 직접 DOM 요소로 스크롤
+      const element = document.querySelector(`[data-section="${id}"]`);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
       }
     },
     [context],

--- a/src/components/landing/ScrollHint.tsx
+++ b/src/components/landing/ScrollHint.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from "lucide-react";
+import { useViewportHeight } from "src/hooks/useViewportHeight";
 
 interface ScrollHintProps {
   onClick?: () => void;
@@ -9,6 +10,13 @@ export function ScrollHint({
   onClick,
   text = "Explore Templates",
 }: ScrollHintProps) {
+  const { isSmallViewport } = useViewportHeight();
+
+  // 작은 화면에서는 ScrollHint를 숨김 (일반 스크롤 모드에서는 불필요)
+  if (isSmallViewport) {
+    return null;
+  }
+
   return (
     <button
       onClick={onClick}

--- a/src/components/template-gallery/AddBlogExampleSheet.tsx
+++ b/src/components/template-gallery/AddBlogExampleSheet.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { Loader2, Sparkles, Send } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "src/components/ui/sheet";
+import { Input } from "src/components/ui/input";
+import { Label } from "src/components/ui/label";
+import { Button } from "src/components/ui/button";
+import { fetchBlogMetadata } from "src/lib/fetchBlogMetadata";
+import { supabase } from "src/lib/supabaseClient";
+import { toast } from "sonner";
+
+interface AddBlogExampleSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+export function AddBlogExampleSheet({
+  open,
+  onOpenChange,
+  onSuccess,
+}: AddBlogExampleSheetProps) {
+  const [url, setUrl] = useState("");
+  const [authorName, setAuthorName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!url.trim()) {
+      toast.error("URL을 입력해주세요");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      // 1. 메타데이터 가져오기
+      toast.loading("메타데이터를 가져오는 중...", { id: "fetch-metadata" });
+      const metadata = await fetchBlogMetadata(url);
+      toast.dismiss("fetch-metadata");
+
+      // 2. Supabase에 저장
+      toast.loading("저장 중...", { id: "save-template" });
+      const { error } = await supabase.from("template").insert({
+        title: metadata.title,
+        description: metadata.description,
+        thumbnail: metadata.image || "",
+        template_type: "blog_only",
+        blog_url: metadata.url,
+        blog_title: metadata.title,
+        blog_description: metadata.description,
+        blog_image: metadata.image,
+        author_name: authorName || metadata.author || null,
+        data: {},
+        userId: "anonymous",
+        createdAt: new Date().toISOString(),
+      });
+      toast.dismiss("save-template");
+
+      if (error) throw error;
+
+      toast.success("사용 예시가 추가되었습니다!");
+      resetForm();
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (err) {
+      toast.dismiss("fetch-metadata");
+      toast.dismiss("save-template");
+      console.error("Error:", err);
+      toast.error("추가에 실패했습니다. URL을 확인해주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const resetForm = () => {
+    setUrl("");
+    setAuthorName("");
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      resetForm();
+    }
+    onOpenChange(open);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !isSubmitting) {
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent side="right" className="w-[400px] sm:max-w-[400px]">
+        <SheetHeader className="mb-6">
+          <SheetTitle className="flex items-center gap-2 text-white">
+            <Sparkles className="w-5 h-5 text-purple-400" />
+            사용 예시 추가
+          </SheetTitle>
+          <SheetDescription>
+            블로그 URL을 입력하면 자동으로 정보를 가져와 추가합니다
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-6">
+          {/* URL 입력 */}
+          <div className="space-y-2">
+            <Label htmlFor="blog-url" className="text-white">
+              블로그 URL
+            </Label>
+            <Input
+              id="blog-url"
+              type="url"
+              placeholder="https://..."
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSubmitting}
+              className="bg-background/50"
+            />
+          </div>
+
+          {/* 저자명 입력 (선택) */}
+          <div className="space-y-2">
+            <Label htmlFor="author-name" className="text-white">
+              저자명 (선택)
+            </Label>
+            <Input
+              id="author-name"
+              type="text"
+              placeholder="작성자 이름 (비워두면 자동 추출)"
+              value={authorName}
+              onChange={(e) => setAuthorName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSubmitting}
+              className="bg-background/50"
+            />
+            <p className="text-xs text-muted-foreground">
+              비워두면 블로그에서 자동으로 추출합니다
+            </p>
+          </div>
+
+          {/* 제출 버튼 */}
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || !url.trim()}
+            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                처리 중...
+              </>
+            ) : (
+              <>
+                <Send className="w-4 h-4 mr-2" />
+                추가하기
+              </>
+            )}
+          </Button>
+
+          {/* 안내 문구 */}
+          <p className="text-xs text-center text-muted-foreground">
+            URL을 입력하면 제목, 설명, 이미지를 자동으로 가져옵니다
+          </p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/template-gallery/AddBlogExampleSheet.tsx
+++ b/src/components/template-gallery/AddBlogExampleSheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Loader2, Sparkles, Send } from "lucide-react";
+import { Loader2, Send } from "lucide-react";
 import { toast } from "sonner";
 import {
   Sheet,
@@ -7,9 +7,9 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription,
+  SheetFooter,
 } from "src/components/ui/sheet";
 import { Input } from "src/components/ui/input";
-import { Label } from "src/components/ui/label";
 import { Button } from "src/components/ui/button";
 import { fetchBlogMetadata } from "src/lib/fetchBlogMetadata";
 import { supabase } from "src/lib/supabaseClient";
@@ -97,23 +97,17 @@ export function AddBlogExampleSheet({
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent side="right" className="w-[400px] sm:max-w-[400px]">
-        <SheetHeader className="mb-6">
-          <SheetTitle className="flex items-center gap-2 text-white">
-            <Sparkles className="h-5 w-5 text-purple-400" />
-            사용 예시 추가
-          </SheetTitle>
+      <SheetContent inner="center">
+        <SheetHeader>
+          <SheetTitle>사용 예시 추가</SheetTitle>
           <SheetDescription>
             블로그 URL을 입력하면 자동으로 정보를 가져와 추가합니다
           </SheetDescription>
         </SheetHeader>
-
-        <div className="space-y-6">
+        <div className="flex min-w-fit flex-col overflow-y-auto pt-[14px]">
           {/* URL 입력 */}
-          <div className="space-y-2">
-            <Label htmlFor="blog-url" className="text-white">
-              블로그 URL
-            </Label>
+          <div className="mb-8">
+            <p className="mb-3 text-[13px] text-[#9292A1]">블로그 URL</p>
             <Input
               id="blog-url"
               type="url"
@@ -122,15 +116,12 @@ export function AddBlogExampleSheet({
               onChange={(e) => setUrl(e.target.value)}
               onKeyDown={handleKeyDown}
               disabled={isSubmitting}
-              className="bg-background/50"
             />
           </div>
 
           {/* 저자명 입력 (선택) */}
-          <div className="space-y-2">
-            <Label htmlFor="author-name" className="text-white">
-              저자명 (선택)
-            </Label>
+          <div className="mb-8">
+            <p className="mb-3 text-[13px] text-[#9292A1]">저자명 (선택)</p>
             <Input
               id="author-name"
               type="text"
@@ -139,19 +130,14 @@ export function AddBlogExampleSheet({
               onChange={(e) => setAuthorName(e.target.value)}
               onKeyDown={handleKeyDown}
               disabled={isSubmitting}
-              className="bg-background/50"
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="mt-2 text-xs text-[#9292A1]">
               비워두면 블로그에서 자동으로 추출합니다
             </p>
           </div>
-
-          {/* 제출 버튼 */}
-          <Button
-            onClick={handleSubmit}
-            disabled={isSubmitting || !url.trim()}
-            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
-          >
+        </div>
+        <SheetFooter className="mt-[96px] flex justify-center gap-2 sm:justify-center">
+          <Button onClick={handleSubmit} disabled={isSubmitting || !url.trim()}>
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -164,12 +150,7 @@ export function AddBlogExampleSheet({
               </>
             )}
           </Button>
-
-          {/* 안내 문구 */}
-          <p className="text-center text-xs text-muted-foreground">
-            URL을 입력하면 제목, 설명, 이미지를 자동으로 가져옵니다
-          </p>
-        </div>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/src/components/template-gallery/AddBlogExampleSheet.tsx
+++ b/src/components/template-gallery/AddBlogExampleSheet.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Loader2, Sparkles, Send } from "lucide-react";
+import { toast } from "sonner";
 import {
   Sheet,
   SheetContent,
@@ -12,7 +13,6 @@ import { Label } from "src/components/ui/label";
 import { Button } from "src/components/ui/button";
 import { fetchBlogMetadata } from "src/lib/fetchBlogMetadata";
 import { supabase } from "src/lib/supabaseClient";
-import { toast } from "sonner";
 
 interface AddBlogExampleSheetProps {
   open: boolean;
@@ -100,7 +100,7 @@ export function AddBlogExampleSheet({
       <SheetContent side="right" className="w-[400px] sm:max-w-[400px]">
         <SheetHeader className="mb-6">
           <SheetTitle className="flex items-center gap-2 text-white">
-            <Sparkles className="w-5 h-5 text-purple-400" />
+            <Sparkles className="h-5 w-5 text-purple-400" />
             사용 예시 추가
           </SheetTitle>
           <SheetDescription>
@@ -154,19 +154,19 @@ export function AddBlogExampleSheet({
           >
             {isSubmitting ? (
               <>
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 처리 중...
               </>
             ) : (
               <>
-                <Send className="w-4 h-4 mr-2" />
+                <Send className="mr-2 h-4 w-4" />
                 추가하기
               </>
             )}
           </Button>
 
           {/* 안내 문구 */}
-          <p className="text-xs text-center text-muted-foreground">
+          <p className="text-center text-xs text-muted-foreground">
             URL을 입력하면 제목, 설명, 이미지를 자동으로 가져옵니다
           </p>
         </div>

--- a/src/components/template-gallery/BlogCard.tsx
+++ b/src/components/template-gallery/BlogCard.tsx
@@ -1,0 +1,53 @@
+import { motion } from "framer-motion";
+import { ExternalLink } from "lucide-react";
+import { Template } from "src/components/gallery/GalleryItem";
+
+interface BlogCardProps {
+  template: Template;
+  onClick?: () => void;
+}
+
+export function BlogCard({ template }: BlogCardProps) {
+  const displayImage = template.blog_image || template.thumbnail;
+  const displayTitle = template.blog_title || template.title;
+
+  const handleBlogClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (template.blog_url) {
+      window.open(template.blog_url, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  return (
+    <motion.div
+      className="relative w-[280px] h-[160px] rounded-xl overflow-hidden shrink-0 border border-border/30 bg-card"
+      whileHover={{ scale: 1.02 }}
+      transition={{ duration: 0.3 }}
+    >
+      {/* 이미지 */}
+      {displayImage ? (
+        <img
+          src={displayImage}
+          alt={displayTitle}
+          className="w-full h-full object-cover"
+          draggable={false}
+        />
+      ) : (
+        <div className="w-full h-full bg-gradient-to-br from-purple-500/20 to-pink-500/20 flex items-center justify-center">
+          <span className="text-4xl">📝</span>
+        </div>
+      )}
+
+      {/* 블로그 버튼만 표시 */}
+      <motion.button
+        onClick={handleBlogClick}
+        className="absolute bottom-3 right-3 flex items-center gap-1.5 px-2.5 py-1.5 bg-purple-500/80 hover:bg-purple-500 backdrop-blur-sm rounded-full text-white text-xs font-medium transition-colors"
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
+        <ExternalLink className="w-3 h-3" />
+        Blog
+      </motion.button>
+    </motion.div>
+  );
+}

--- a/src/components/template-gallery/BlogCard.tsx
+++ b/src/components/template-gallery/BlogCard.tsx
@@ -1,15 +1,15 @@
 import { motion } from "framer-motion";
 import { ExternalLink } from "lucide-react";
 import { Template } from "src/components/gallery/GalleryItem";
+import { getDisplayImageAndTitle } from "./templateUtils";
 
 interface BlogCardProps {
   template: Template;
   onClick?: () => void;
 }
 
-export function BlogCard({ template }: BlogCardProps) {
-  const displayImage = template.blog_image || template.thumbnail;
-  const displayTitle = template.blog_title || template.title;
+export function BlogCard({ template, onClick }: BlogCardProps) {
+  const { displayImage, displayTitle } = getDisplayImageAndTitle(template);
 
   const handleBlogClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -20,9 +20,10 @@ export function BlogCard({ template }: BlogCardProps) {
 
   return (
     <motion.div
-      className="relative h-[160px] w-[280px] shrink-0 overflow-hidden rounded-xl border border-border/30 bg-card"
+      className="relative h-[160px] w-[280px] shrink-0 cursor-pointer overflow-hidden rounded-xl border border-border/30 bg-card"
       whileHover={{ scale: 1.03 }}
       transition={{ duration: 0.3 }}
+      onClick={onClick}
     >
       {/* 이미지 */}
       {displayImage ? (

--- a/src/components/template-gallery/BlogCard.tsx
+++ b/src/components/template-gallery/BlogCard.tsx
@@ -21,7 +21,7 @@ export function BlogCard({ template }: BlogCardProps) {
   return (
     <motion.div
       className="relative w-[280px] h-[160px] rounded-xl overflow-hidden shrink-0 border border-border/30 bg-card"
-      whileHover={{ scale: 1.02 }}
+      whileHover={{ scale: 1.03   }}
       transition={{ duration: 0.3 }}
     >
       {/* 이미지 */}

--- a/src/components/template-gallery/BlogCard.tsx
+++ b/src/components/template-gallery/BlogCard.tsx
@@ -20,8 +20,8 @@ export function BlogCard({ template }: BlogCardProps) {
 
   return (
     <motion.div
-      className="relative w-[280px] h-[160px] rounded-xl overflow-hidden shrink-0 border border-border/30 bg-card"
-      whileHover={{ scale: 1.03   }}
+      className="relative h-[160px] w-[280px] shrink-0 overflow-hidden rounded-xl border border-border/30 bg-card"
+      whileHover={{ scale: 1.03 }}
       transition={{ duration: 0.3 }}
     >
       {/* 이미지 */}
@@ -29,11 +29,11 @@ export function BlogCard({ template }: BlogCardProps) {
         <img
           src={displayImage}
           alt={displayTitle}
-          className="w-full h-full object-cover"
+          className="h-full w-full object-cover"
           draggable={false}
         />
       ) : (
-        <div className="w-full h-full bg-gradient-to-br from-purple-500/20 to-pink-500/20 flex items-center justify-center">
+        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-purple-500/20 to-pink-500/20">
           <span className="text-4xl">📝</span>
         </div>
       )}
@@ -41,11 +41,11 @@ export function BlogCard({ template }: BlogCardProps) {
       {/* 블로그 버튼만 표시 */}
       <motion.button
         onClick={handleBlogClick}
-        className="absolute bottom-3 right-3 flex items-center gap-1.5 px-2.5 py-1.5 bg-purple-500/80 hover:bg-purple-500 backdrop-blur-sm rounded-full text-white text-xs font-medium transition-colors"
+        className="absolute bottom-3 right-3 flex items-center gap-1.5 rounded-full bg-purple-500/80 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition-colors hover:bg-purple-500"
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
       >
-        <ExternalLink className="w-3 h-3" />
+        <ExternalLink className="h-3 w-3" />
         Blog
       </motion.button>
     </motion.div>

--- a/src/components/template-gallery/TemplateGallery.tsx
+++ b/src/components/template-gallery/TemplateGallery.tsx
@@ -7,7 +7,7 @@ import { Template } from "src/components/gallery/GalleryItem";
 import { useScrollToSection } from "src/components/landing/FullPageScroller";
 import { Button } from "src/components/ui/button";
 import { useSupabaseTemplates } from "./useSupabaseTemplates";
-import { Marquee, ParticleBackground } from "./animations";
+import { Marquee } from "./animations";
 import { BlogCard } from "./BlogCard";
 import { AddBlogExampleSheet } from "./AddBlogExampleSheet";
 
@@ -39,7 +39,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
       {/* Particle Background */}
-      <ParticleBackground particleCount={60} />
+      {/* <ParticleBackground particleCount={60} /> */}
 
       {/* Content */}
       <div className="relative z-10 mx-auto flex h-full w-full max-w-[1200px] flex-col px-6 py-8">

--- a/src/components/template-gallery/TemplateGallery.tsx
+++ b/src/components/template-gallery/TemplateGallery.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
 import { motion } from "framer-motion";
 import { ChevronUp, Plus } from "lucide-react";
-import { useScrollToSection } from "../landing/FullPageScroller";
-import { useSupabaseTemplates } from "./useSupabaseTemplates";
 import { Skeleton } from "src/components/ui/skeleton";
 import { Template } from "src/components/gallery/GalleryItem";
+import { useScrollToSection } from "../landing/FullPageScroller";
+import { Button } from "../ui/button";
+import { useSupabaseTemplates } from "./useSupabaseTemplates";
 import { Marquee, ParticleBackground } from "./animations";
 import { BlogCard } from "./BlogCard";
 import { AddBlogExampleSheet } from "./AddBlogExampleSheet";
@@ -26,7 +27,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
     (template: Template) => {
       onApply(template);
     },
-    [onApply]
+    [onApply],
   );
 
   const handleAddSuccess = useCallback(() => {
@@ -34,84 +35,59 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
   }, [refetch]);
 
   return (
-    <div className="relative h-full flex flex-col overflow-hidden">
+    <div className="relative flex h-full flex-col overflow-hidden">
       {/* Particle Background */}
       <ParticleBackground particleCount={60} />
 
       {/* Content */}
-      <div className="relative z-10 h-full flex flex-col px-6 py-8 max-w-[1200px] mx-auto w-full">
+      <div className="relative z-10 mx-auto flex h-full w-full max-w-[1200px] flex-col px-6 py-8">
         {/* Header */}
-        <motion.div
-          className="text-center mb-6"
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-        >
-          <motion.p
-            className="text-sm text-muted-foreground mb-2"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, delay: 0.1 }}
-          >
-            Pick a style, make it yours
-          </motion.p>
-          <motion.h2
-            className="text-4xl font-bold bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent"
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-          >
-            Template Gallery
-          </motion.h2>
-        </motion.div>
 
         {/* Floating Buttons */}
-        <div className="absolute top-6 right-6 z-20 flex items-center gap-2">
+        <div className="absolute right-6 top-6 z-20 flex items-center gap-2">
           {/* Add Example Button */}
-          <motion.button
-            onClick={() => setIsAddSheetOpen(true)}
-            className="flex items-center gap-1.5 px-3 py-2 text-sm text-purple-300 hover:text-purple-200 bg-purple-500/20 hover:bg-purple-500/30 backdrop-blur-sm rounded-full border border-purple-500/30 transition-colors"
+          <motion.div
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.5, delay: 0.2 }}
             whileHover={{ scale: 1.05, y: -2 }}
             whileTap={{ scale: 0.95 }}
           >
-            <Plus className="w-4 h-4" />
-            사용 예시 추가
-          </motion.button>
+            <Button onClick={() => setIsAddSheetOpen(true)} variant="default">
+              <Plus className="h-4 w-4" />
+              사용 예시 추가
+            </Button>
+          </motion.div>
 
           {/* Back Button */}
-          <motion.button
+          <motion.div
             onClick={handleScrollToEditor}
-            className="flex items-center gap-1.5 px-3 py-2 text-sm text-muted-foreground hover:text-foreground bg-background/50 backdrop-blur-sm rounded-full border border-border/30 transition-colors"
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.5, delay: 0.3 }}
             whileHover={{ scale: 1.05, y: -2 }}
             whileTap={{ scale: 0.95 }}
           >
-            <ChevronUp className="w-4 h-4" />
-            Editor
-          </motion.button>
+            <Button onClick={handleScrollToEditor} variant="outline">
+              <ChevronUp className="h-4 w-4" />
+              Editor
+            </Button>
+          </motion.div>
         </div>
 
         {/* Error State */}
         {error && (
-          <div className="flex items-center justify-center h-40 text-red-400">
+          <div className="flex h-40 items-center justify-center text-red-400">
             Failed to load templates. Please try again later.
           </div>
         )}
 
         {/* Loading State */}
         {isLoading && (
-          <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-1 items-center justify-center">
             <div className="flex gap-4">
               {[...Array(3)].map((_, i) => (
-                <Skeleton
-                  key={i}
-                  className="w-[280px] h-[160px] rounded-xl"
-                />
+                <Skeleton key={i} className="h-[160px] w-[280px] rounded-xl" />
               ))}
             </div>
           </div>
@@ -120,7 +96,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
         {/* Marquee View */}
         {!isLoading && !error && templates.length > 0 && (
           <motion.div
-            className="flex-1 flex flex-col justify-center gap-4"
+            className="flex flex-1 flex-col justify-center gap-4"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
@@ -173,7 +149,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
 
         {/* Empty State */}
         {!isLoading && !error && templates.length === 0 && (
-          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+          <div className="flex flex-1 items-center justify-center text-muted-foreground">
             No templates available
           </div>
         )}
@@ -207,7 +183,7 @@ function MarqueeCard({ template, onClick }: MarqueeCardProps) {
 
   return (
     <motion.div
-      className="relative w-[280px] h-[160px] rounded-xl overflow-hidden cursor-pointer shrink-0 border border-border/30"
+      className="relative h-[160px] w-[280px] shrink-0 cursor-pointer overflow-hidden rounded-xl border border-border/30"
       onClick={onClick}
       whileHover={{ scale: 1.02, y: -5 }}
       transition={{ duration: 0.3 }}
@@ -215,21 +191,21 @@ function MarqueeCard({ template, onClick }: MarqueeCardProps) {
       <img
         src={template.thumbnail}
         alt={template.title}
-        className="w-full h-full object-cover"
+        className="h-full w-full object-cover"
         draggable={false}
       />
       <motion.div
-        className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 hover:opacity-100 transition-opacity flex items-end p-4"
+        className="absolute inset-0 flex items-end bg-gradient-to-t from-black/80 via-black/20 to-transparent p-4 opacity-0 transition-opacity hover:opacity-100"
         initial={{ opacity: 0 }}
         whileHover={{ opacity: 1 }}
       >
         <div className="flex-1">
-          <h3 className="text-white font-medium text-sm">{template.title}</h3>
-          <p className="text-gray-300 text-xs mt-1 line-clamp-1">
+          <h3 className="text-sm font-medium text-white">{template.title}</h3>
+          <p className="mt-1 line-clamp-1 text-xs text-gray-300">
             {template.description}
           </p>
           {template.author_name && (
-            <p className="text-gray-400 text-xs mt-1">
+            <p className="mt-1 text-xs text-gray-400">
               by {template.author_name}
             </p>
           )}
@@ -240,7 +216,7 @@ function MarqueeCard({ template, onClick }: MarqueeCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="ml-2 text-xs text-purple-300 hover:text-purple-200 underline"
+            className="ml-2 text-xs text-purple-300 underline hover:text-purple-200"
           >
             Blog
           </a>

--- a/src/components/template-gallery/TemplateGallery.tsx
+++ b/src/components/template-gallery/TemplateGallery.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { ChevronUp, Plus } from "lucide-react";
 import { Skeleton } from "src/components/ui/skeleton";
 import { Template } from "src/components/gallery/GalleryItem";
-import { useScrollToSection } from "../landing/FullPageScroller";
-import { Button } from "../ui/button";
+import { useScrollToSection } from "src/components/landing/FullPageScroller";
+import { Button } from "src/components/ui/button";
 import { useSupabaseTemplates } from "./useSupabaseTemplates";
 import { Marquee, ParticleBackground } from "./animations";
 import { BlogCard } from "./BlogCard";
@@ -15,6 +16,7 @@ interface TemplateGalleryProps {
 }
 
 export function TemplateGallery({ onApply }: TemplateGalleryProps) {
+  const { t } = useTranslation("translation");
   const { templates, isLoading, error, refetch } = useSupabaseTemplates();
   const { scrollToSection } = useScrollToSection();
   const [isAddSheetOpen, setIsAddSheetOpen] = useState(false);
@@ -55,13 +57,12 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
           >
             <Button onClick={() => setIsAddSheetOpen(true)} variant="default">
               <Plus className="h-4 w-4" />
-              사용 예시 추가
+              {t("gallery.addExample")}
             </Button>
           </motion.div>
 
           {/* Back Button */}
           <motion.div
-            onClick={handleScrollToEditor}
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.5, delay: 0.3 }}
@@ -70,7 +71,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
           >
             <Button onClick={handleScrollToEditor} variant="outline">
               <ChevronUp className="h-4 w-4" />
-              Editor
+              {t("gallery.editor")}
             </Button>
           </motion.div>
         </div>
@@ -78,7 +79,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
         {/* Error State */}
         {error && (
           <div className="flex h-40 items-center justify-center text-red-400">
-            Failed to load templates. Please try again later.
+            {t("gallery.failedLoadTemplates")}
           </div>
         )}
 
@@ -150,7 +151,7 @@ export function TemplateGallery({ onApply }: TemplateGalleryProps) {
         {/* Empty State */}
         {!isLoading && !error && templates.length === 0 && (
           <div className="flex flex-1 items-center justify-center text-muted-foreground">
-            No templates available
+            {t("gallery.noTemplates")}
           </div>
         )}
       </div>
@@ -172,6 +173,7 @@ interface MarqueeCardProps {
 }
 
 function MarqueeCard({ template, onClick }: MarqueeCardProps) {
+  const { t } = useTranslation("translation");
   // blog_only 타입은 BlogCard로 렌더링
   if (template.template_type === "blog_only") {
     return <BlogCard template={template} onClick={onClick} />;
@@ -206,7 +208,7 @@ function MarqueeCard({ template, onClick }: MarqueeCardProps) {
           </p>
           {template.author_name && (
             <p className="mt-1 text-xs text-gray-400">
-              by {template.author_name}
+              {t("gallery.by")} {template.author_name}
             </p>
           )}
         </div>
@@ -218,7 +220,7 @@ function MarqueeCard({ template, onClick }: MarqueeCardProps) {
             onClick={(e) => e.stopPropagation()}
             className="ml-2 text-xs text-purple-300 underline hover:text-purple-200"
           >
-            Blog
+            {t("gallery.blog")}
           </a>
         )}
       </motion.div>

--- a/src/components/template-gallery/templateUtils.ts
+++ b/src/components/template-gallery/templateUtils.ts
@@ -1,0 +1,14 @@
+import { Template } from "src/components/gallery/GalleryItem";
+
+/**
+ * 템플릿에서 표시할 이미지와 제목을 가져옵니다.
+ * blog_image/blog_title이 있으면 우선 사용하고, 없으면 thumbnail/title을 사용합니다.
+ */
+export function getDisplayImageAndTitle(template: Template): {
+  displayImage: string | undefined;
+  displayTitle: string;
+} {
+  const displayImage = template.blog_image || template.thumbnail;
+  const displayTitle = template.blog_title || template.title;
+  return { displayImage, displayTitle };
+}

--- a/src/components/template-gallery/useSupabaseTemplates.ts
+++ b/src/components/template-gallery/useSupabaseTemplates.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { supabase } from "src/lib/supabaseClient";
 import { Template as GalleryTemplate } from "src/components/gallery/GalleryItem";
 import templatesData from "src/data/templates.json";
@@ -11,44 +11,44 @@ export function useSupabaseTemplates() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    async function fetchTemplates() {
-      setIsLoading(true);
-      setError(null);
+  const fetchTemplates = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
-      try {
-        const { data, error: supabaseError } = await supabase
-          .from("template")
-          .select("*");
+    try {
+      const { data, error: supabaseError } = await supabase
+        .from("template")
+        .select("*");
 
-        if (supabaseError) {
-          throw new Error(supabaseError.message);
-        }
-
-        const allTemplates = (data as GalleryTemplate[]) || [];
-
-        // templates.json에 있는 템플릿을 우선 정렬
-        const sortedTemplates = allTemplates.sort((a, b) => {
-          const aIsPriority = PRIORITY_TEMPLATE_IDS.has(a.id);
-          const bIsPriority = PRIORITY_TEMPLATE_IDS.has(b.id);
-
-          if (aIsPriority && !bIsPriority) return -1;
-          if (!aIsPriority && bIsPriority) return 1;
-          return 0;
-        });
-
-        setTemplates(sortedTemplates);
-      } catch (err) {
-        console.error("Error fetching templates:", err);
-        setError(err instanceof Error ? err : new Error("Unknown error"));
-        setTemplates([]);
-      } finally {
-        setIsLoading(false);
+      if (supabaseError) {
+        throw new Error(supabaseError.message);
       }
-    }
 
-    fetchTemplates();
+      const allTemplates = (data as GalleryTemplate[]) || [];
+
+      // templates.json에 있는 템플릿을 우선 정렬
+      const sortedTemplates = allTemplates.sort((a, b) => {
+        const aIsPriority = PRIORITY_TEMPLATE_IDS.has(a.id);
+        const bIsPriority = PRIORITY_TEMPLATE_IDS.has(b.id);
+
+        if (aIsPriority && !bIsPriority) return -1;
+        if (!aIsPriority && bIsPriority) return 1;
+        return 0;
+      });
+
+      setTemplates(sortedTemplates);
+    } catch (err) {
+      console.error("Error fetching templates:", err);
+      setError(err instanceof Error ? err : new Error("Unknown error"));
+      setTemplates([]);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
-  return { templates, isLoading, error };
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  return { templates, isLoading, error, refetch: fetchTemplates };
 }

--- a/src/components/thumbnail-maker/MenuBar.tsx
+++ b/src/components/thumbnail-maker/MenuBar.tsx
@@ -1,6 +1,7 @@
 import { MousePointer2, Move, RotateCcw, Shuffle } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import {
   Menubar,
@@ -41,6 +42,7 @@ export function Toolbar({
   isDragMode: boolean;
   setIsDragMode: (isDragMode: boolean) => void;
 }) {
+  const { t } = useTranslation("translation");
   const { onRandomShuffle, onResetTags } = useTagAction();
   const handleChangeDragMode = () => setIsDragMode(!isDragMode);
 
@@ -57,7 +59,7 @@ export function Toolbar({
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p className="text-xs">Reset Canvas</p>
+          <p className="text-xs">{t("toolbar.resetCanvas")}</p>
         </TooltipContent>
       </Tooltip>
 
@@ -68,7 +70,7 @@ export function Toolbar({
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p className="text-xs">Random Shuffle (Ctrl+R)</p>
+          <p className="text-xs">{t("toolbar.randomShuffle")}</p>
         </TooltipContent>
       </Tooltip>
 
@@ -84,7 +86,7 @@ export function Toolbar({
         </TooltipTrigger>
         <TooltipContent>
           <p className="text-xs">
-            {isDragMode ? "Drag Mode" : "Select Mode"} (Ctrl+D)
+            {isDragMode ? t("toolbar.dragMode") : t("toolbar.selectMode")}
           </p>
         </TooltipContent>
       </Tooltip>
@@ -102,17 +104,18 @@ export function Toolbar({
 }
 
 function CanvasSizeSegment() {
+  const { t } = useTranslation("translation");
   const { currentSize } = useCanvasSize();
   const { onSizeChange } = useCanvasSizeAction();
 
-  const sizes: { value: CanvasSizePreset; label: string }[] = [
-    { value: "wide", label: "Wide" },
-    { value: "square", label: "Square" },
+  const sizes: { value: CanvasSizePreset; labelKey: string }[] = [
+    { value: "wide", labelKey: "toolbar.wide" },
+    { value: "square", labelKey: "toolbar.square" },
   ];
 
   return (
     <div className="flex gap-0.5 rounded-md border p-0.5">
-      {sizes.map(({ value, label }) => (
+      {sizes.map(({ value, labelKey }) => (
         <Button
           key={value}
           variant="ghost"
@@ -124,7 +127,7 @@ function CanvasSizeSegment() {
           }
           onClick={() => onSizeChange(value)}
         >
-          {label}
+          {t(labelKey as "toolbar.wide" | "toolbar.square")}
         </Button>
       ))}
     </div>
@@ -136,6 +139,7 @@ function TemplateMenu({
 }: {
   getImageFile: () => Promise<Blob | null>;
 }) {
+  const { t } = useTranslation("translation");
   const [isSaveTemplateSheetOpen, setIsSaveTemplateSheetOpen] = useState(false);
   const [isDownloadTemplateSheetOpen, setIsDownloadTemplateSheetOpen] =
     useState(false);
@@ -145,21 +149,21 @@ function TemplateMenu({
   return (
     <>
       <MenubarMenu>
-        <MenubarTrigger>Template</MenubarTrigger>
+        <MenubarTrigger>{t("menuBar.template")}</MenubarTrigger>
         <MenubarContent>
           <Link to="/gallery">
-            <MenubarItem>Go to Many Templates</MenubarItem>
+            <MenubarItem>{t("menuBar.goToManyTemplates")}</MenubarItem>
           </Link>
           <MenubarSeparator />
           <MenubarItem onClick={() => setIsSaveTemplateSheetOpen(true)}>
-            Save Template
+            {t("menuBar.saveTemplate")}
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={() => setIsDownloadTemplateSheetOpen(true)}>
-            Download Template to Local
+            {t("menuBar.downloadTemplateToLocal")}
           </MenubarItem>
           <MenubarItem onClick={() => setIsImportTemplateSheetOpen(true)}>
-            Import Template
+            {t("menuBar.importTemplate")}
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
+++ b/src/components/thumbnail-maker/SubMenu/AlignmentMenu.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { TagAlignment, useTagStyle, useTagStyleAction } from "../Tag.context";
 import { AlignLeftIcon, AlignCenterIcon, AlignRightIcon } from "lucide-react";
 import { Button } from "../../ui/button";
@@ -6,20 +7,21 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 const alignmentOptions: {
   value: TagAlignment;
   icon: typeof AlignLeftIcon;
-  label: string;
+  labelKey: string;
 }[] = [
-  { value: "start", icon: AlignLeftIcon, label: "Align Left" },
-  { value: "center", icon: AlignCenterIcon, label: "Align Center" },
-  { value: "end", icon: AlignRightIcon, label: "Align Right" },
+  { value: "start", icon: AlignLeftIcon, labelKey: "toolbar.alignLeft" },
+  { value: "center", icon: AlignCenterIcon, labelKey: "toolbar.alignCenter" },
+  { value: "end", icon: AlignRightIcon, labelKey: "toolbar.alignRight" },
 ];
 
 export const AlignmentMenu = () => {
+  const { t } = useTranslation("translation");
   const { alignment } = useTagStyle();
   const { setAlignment } = useTagStyleAction();
 
   return (
     <div className="flex gap-0.5">
-      {alignmentOptions.map(({ value, icon: Icon, label }) => (
+      {alignmentOptions.map(({ value, icon: Icon, labelKey }) => (
         <Tooltip key={value}>
           <TooltipTrigger asChild>
             <Button
@@ -32,7 +34,14 @@ export const AlignmentMenu = () => {
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p className="text-xs">{label}</p>
+            <p className="text-xs">
+              {t(
+                labelKey as
+                  | "toolbar.alignLeft"
+                  | "toolbar.alignCenter"
+                  | "toolbar.alignRight",
+              )}
+            </p>
           </TooltipContent>
         </Tooltip>
       ))}

--- a/src/components/thumbnail-maker/SubMenu/DownloadTemplateToLocalConfirm.tsx
+++ b/src/components/thumbnail-maker/SubMenu/DownloadTemplateToLocalConfirm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +21,7 @@ export function DownloadTemplateToLocalConfirm({
   isOpen,
   onClose,
 }: DownloadTemplateToLocalConfirmProps) {
+  const { t } = useTranslation("translation");
   const { tags } = useTagList();
   const { currentPalette } = usePalette();
 
@@ -64,15 +66,15 @@ export function DownloadTemplateToLocalConfirm({
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Download Template</AlertDialogTitle>
+          <AlertDialogTitle>{t("downloadTemplate.title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            Download the template you made to your local device.
+            {t("downloadTemplate.description")}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{t("downloadTemplate.cancel")}</AlertDialogCancel>
           <AlertDialogAction onClick={onDownloadTemplate}>
-            Download
+            {t("downloadTemplate.download")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/thumbnail-maker/SubMenu/ImportTemplateConfirm.tsx
+++ b/src/components/thumbnail-maker/SubMenu/ImportTemplateConfirm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,23 +18,25 @@ export function ImportTemplateConfirm({
   isOpen: boolean;
   onClose: () => void;
 }) {
+  const { t } = useTranslation("translation");
   const { handleImportTemplate } = useImportTemplate();
 
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Import Template</AlertDialogTitle>
+          <AlertDialogTitle>{t("importTemplate.title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            <div className="flex items-center gap-1">Warning!</div>
-            The current content on the canvas will be lost. Are you sure you
-            want to import?
+            <div className="flex items-center gap-1">
+              {t("importTemplate.warning")}
+            </div>
+            {t("importTemplate.description")}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{t("importTemplate.cancel")}</AlertDialogCancel>
           <AlertDialogAction onClick={handleImportTemplate}>
-            Import
+            {t("importTemplate.import")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/thumbnail-maker/SubMenu/SaveTemplateSheet.tsx
+++ b/src/components/thumbnail-maker/SubMenu/SaveTemplateSheet.tsx
@@ -1,5 +1,6 @@
 import { InfoIcon } from "lucide-react";
 import { useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Alert, AlertTitle, AlertDescription } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
@@ -27,6 +28,7 @@ export function SaveTemplateSheet({
   onClose: () => void;
   getImageFile: () => Promise<Blob | null>;
 }) {
+  const { t } = useTranslation("translation");
   const { tags } = useTagList();
   const { currentPalette } = usePalette();
 
@@ -72,7 +74,7 @@ export function SaveTemplateSheet({
       }
     } catch (error) {
       console.error("Error uploading thumbnail:", error);
-      toast.error("Error uploading thumbnail");
+      toast.error(t("saveTemplate.toast.error"));
       return null;
     }
   };
@@ -107,45 +109,42 @@ export function SaveTemplateSheet({
         .from("template")
         .insert(requestData);
 
-      toast.success("Template saved successfully");
+      toast.success(t("saveTemplate.toast.success"));
       onClose();
     } catch (error) {
       console.error("Error uploading thumbnail:", error);
-      toast.error("Error uploading thumbnail");
+      toast.error(t("saveTemplate.toast.error"));
     }
   };
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent className="min-w-[520px] pt-[80px]">
         <SheetHeader>
-          <SheetTitle>Save Template</SheetTitle>
-          <SheetDescription>
-            Make the thumbnail you made into a template and share it with
-            others! 🚀
-          </SheetDescription>
+          <SheetTitle>{t("saveTemplate.title")}</SheetTitle>
+          <SheetDescription>{t("saveTemplate.description")}</SheetDescription>
         </SheetHeader>
 
         <div className="grid gap-4 py-4">
           <div className="grid-cols-[80px 1fr] grid items-center gap-4">
             <Label htmlFor="title" className="text-left">
-              Title *
+              {t("saveTemplate.titleLabel")}
             </Label>
             <Input
               id="title"
               className="col-span-3"
-              placeholder="Please enter a title"
+              placeholder={t("saveTemplate.titlePlaceholder")}
               onChange={(e) => (inputValues.current.title = e.target.value)}
               defaultValue={initTitle}
             />
           </div>
           <div className="grid-cols-[80px 1fr] grid items-center gap-4">
             <Label htmlFor="description" className="text-left">
-              Description
+              {t("saveTemplate.descriptionLabel")}
             </Label>
             <Input
               id="description"
               className="col-span-3"
-              placeholder="Please enter a description"
+              placeholder={t("saveTemplate.descriptionPlaceholder")}
               onChange={(e) =>
                 (inputValues.current.description = e.target.value)
               }
@@ -153,23 +152,23 @@ export function SaveTemplateSheet({
           </div>
           <div className="grid-cols-[80px 1fr] grid items-center gap-4">
             <Label htmlFor="blogUrl" className="text-left">
-              Blog URL
+              {t("saveTemplate.blogUrlLabel")}
             </Label>
             <Input
               id="blogUrl"
               className="col-span-3"
-              placeholder="https://"
+              placeholder={t("saveTemplate.blogUrlPlaceholder")}
               onChange={(e) => (inputValues.current.blogUrl = e.target.value)}
             />
           </div>
           <div className="grid-cols-[80px 1fr] grid items-center gap-4">
             <Label htmlFor="username" className="text-left ">
-              Username
+              {t("saveTemplate.usernameLabel")}
             </Label>
             <Input
               id="username"
               className="col-span-3"
-              placeholder="@"
+              placeholder={t("saveTemplate.usernamePlaceholder")}
               onChange={(e) => (inputValues.current.username = e.target.value)}
             />
           </div>
@@ -178,11 +177,9 @@ export function SaveTemplateSheet({
           <Alert variant="outline">
             <InfoIcon className="mt-0 h-4 w-4" />
             <div>
-              <AlertTitle>
-                The added templates are available in the gallery.
-              </AlertTitle>
+              <AlertTitle>{t("saveTemplate.alertTitle")}</AlertTitle>
               <AlertDescription>
-                Only anonymous additions are available at this time.
+                {t("saveTemplate.alertDescription")}
               </AlertDescription>
             </div>
           </Alert>
@@ -191,7 +188,7 @@ export function SaveTemplateSheet({
         <SheetFooter>
           <SheetClose asChild>
             <Button type="submit" onClick={onSaveTemplate}>
-              Save Template
+              {t("saveTemplate.button")}
             </Button>
           </SheetClose>
         </SheetFooter>

--- a/src/components/thumbnail-maker/SubMenu/SubActionMenu.tsx
+++ b/src/components/thumbnail-maker/SubMenu/SubActionMenu.tsx
@@ -1,5 +1,6 @@
 import { ImageIcon } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useUserStats } from "src/hooks/useUserStats";
 import { useTagAction } from "../Tag.context";
@@ -12,6 +13,7 @@ export function SubActionMenu({
   getImageFile: () => Promise<Blob | null>;
   downloadImage: () => void;
 }) {
+  const { t } = useTranslation("translation");
   const [isSaveTemplateSheetOpen, setIsSaveTemplateSheetOpen] = useState(false);
   const [isDownloadTemplateSheetOpen, setIsDownloadTemplateSheetOpen] =
     useState(false);
@@ -23,12 +25,11 @@ export function SubActionMenu({
   const onDownload = () => {
     incrementDownload();
     downloadImage();
-    toast.message("Downloaded Successfully", {
+    toast.message(t("subActionMenu.toast.title"), {
       duration: 5000,
-      description:
-        "Share your carefully crafted image with others through the gallery! 🎨",
+      description: t("subActionMenu.toast.description"),
       action: {
-        label: "Upload",
+        label: t("subActionMenu.toast.upload"),
         onClick: () => {
           setIsSaveTemplateSheetOpen(true);
         },
@@ -39,7 +40,7 @@ export function SubActionMenu({
   return (
     <div className="flex items-center gap-2">
       <Button onClick={onDownload}>
-        <ImageIcon size={20} /> Download Image
+        <ImageIcon size={20} /> {t("subActionMenu.downloadImage")}
       </Button>
     </div>
   );

--- a/src/components/thumbnail-maker/hooks/useSetTemplate.tsx
+++ b/src/components/thumbnail-maker/hooks/useSetTemplate.tsx
@@ -12,6 +12,28 @@ export type TemplateDataType = {
   tags: string;
 };
 
+const VALID_PALETTE_VARIANTS: PaletteVariant[] = [
+  "blue_gradient",
+  "rose_gradient",
+  "yellow_dark",
+  "green_dark",
+  "blue_dark",
+  "purple_light",
+  "blue_light",
+  "green_light",
+  "orange_light",
+  "pink_light",
+];
+
+const DEFAULT_PALETTE: PaletteVariant = "blue_gradient";
+
+function isPaletteVariant(value: unknown): value is PaletteVariant {
+  return (
+    typeof value === "string" &&
+    VALID_PALETTE_VARIANTS.includes(value as PaletteVariant)
+  );
+}
+
 export function useSetTemplate() {
   const [, setTags] = useStorageState<Tag[]>(THUMBNAIL_MAKER_STORAGE_KEY, {
     defaultValue: [],
@@ -25,9 +47,21 @@ export function useSetTemplate() {
     // blog_only 타입 등 data가 null인 경우 무시
     if (!template) return;
 
-    const tags: Tag[] = JSON.parse(template.tags);
-    // TODO: custom palette 추가
-    const palette: PaletteVariant = template.palette.type as PaletteVariant;
+    // JSON.parse를 try-catch로 감싸기
+    let tags: Tag[] = [];
+    try {
+      tags = JSON.parse(template.tags);
+      if (!Array.isArray(tags)) {
+        tags = [];
+      }
+    } catch {
+      tags = [];
+    }
+
+    // palette 타입 가드 사용
+    const palette: PaletteVariant = isPaletteVariant(template.palette.type)
+      ? template.palette.type
+      : DEFAULT_PALETTE;
 
     setTags(tags);
     setPalette(palette);

--- a/src/components/thumbnail-maker/hooks/useSetTemplate.tsx
+++ b/src/components/thumbnail-maker/hooks/useSetTemplate.tsx
@@ -5,7 +5,7 @@ import {
 } from "../assets/constants";
 import { Tag, PaletteVariant } from "../assets/palette.types";
 
-type TemplateDataType = {
+export type TemplateDataType = {
   palette: {
     type: PaletteVariant | string;
   };
@@ -21,7 +21,10 @@ export function useSetTemplate() {
     THUMBNAIL_MAKERS_PALETTE_STORAGE_KEY
   );
 
-  const onUseTemplate = (template: TemplateDataType) => {
+  const onUseTemplate = (template: TemplateDataType | null) => {
+    // blog_only 타입 등 data가 null인 경우 무시
+    if (!template) return;
+
     const tags: Tag[] = JSON.parse(template.tags);
     // TODO: custom palette 추가
     const palette: PaletteVariant = template.palette.type as PaletteVariant;

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -11,7 +11,7 @@ const alertVariants = cva(
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
         outline:
-          "border-outline bg-transparent text-foreground border-[1px] border-white/30 px-3",
+          "bg-transparent text-foreground border-[1px] border-white/30 px-3",
       },
     },
     defaultVariants: {

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -12,7 +12,7 @@ const alertVariants = cva(
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
         outline:
-          "border-outline bg-transparent text-foreground border-[1px] border-white/70 px-3",
+          "border-outline bg-transparent text-foreground border-[1px] border-white/30 px-3",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "src/lib/utils";
 import { PropsWithChildren } from "react";
 
 const buttonVariants = cva(
-  "inline-flex items-center  whitespace-nowrap	 justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-nowrap ",
+  "inline-flex items-center gap-2  whitespace-nowrap	 justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-nowrap ",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,8 +4,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { PropsWithChildren } from "react";
 import { cn } from "src/lib/utils";
 
+// Note: gap-2 has been removed from base class. If you need icon+text spacing,
+// add gap via the Button's className prop (e.g., <Button className="gap-2">)
 const buttonVariants = cva(
-  "inline-flex items-center gap-2  whitespace-nowrap	 justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-nowrap ",
+  "inline-flex items-center whitespace-nowrap justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-nowrap",
   {
     variants: {
       variant: {

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -115,7 +115,7 @@ const MenubarItem = React.forwardRef<
   <MenubarPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-[#282B35] focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -193,7 +193,7 @@ const MenubarSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <MenubarPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-[#464856]", className)}
     {...props}
   />
 ));

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "src/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,7 +1,6 @@
-import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
-
-import { cn } from "src/lib/utils"
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import { cn } from "src/lib/utils";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
@@ -18,8 +17,8 @@ const ScrollArea = React.forwardRef<
     <ScrollBar />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
-))
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
@@ -34,13 +33,13 @@ const ScrollBar = React.forwardRef<
         "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
         "h-2.5 flex-col border-t border-t-transparent p-[1px]",
-      className
+      className,
     )}
     {...props}
   >
     <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
-))
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/src/hooks/useViewportHeight.ts
+++ b/src/hooks/useViewportHeight.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+
+const VIEWPORT_THRESHOLD = 840;
+
+/**
+ * 뷰포트 높이를 감지하고 1000px 기준으로 작은 화면 여부를 판단하는 훅
+ * @returns { height: number, isSmallViewport: boolean }
+ */
+export function useViewportHeight() {
+  const [height, setHeight] = useState(() => {
+    if (typeof window !== "undefined") {
+      return window.innerHeight;
+    }
+    return VIEWPORT_THRESHOLD;
+  });
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    const handleResize = () => {
+      // 디바운싱으로 성능 최적화
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setHeight(window.innerHeight);
+      }, 150);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    // 초기 높이 설정 (SSR 대응)
+    if (typeof window !== "undefined") {
+      setHeight(window.innerHeight);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  const isSmallViewport = height < VIEWPORT_THRESHOLD;
+
+  return { height, isSmallViewport };
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -8,5 +8,38 @@
   "linters": "Lint all code at save",
   "linters-desc": "Built with ESLint, Prettier, Stylelint, and Commitlint",
   "hero-title": "Building Apps with the best DX we love",
-  "get-started": "Get Started"
+  "get-started": "Get Started",
+  "addBlog": {
+    "title": "Add Usage Example",
+    "description": "Enter a blog URL to automatically fetch and add information",
+    "urlLabel": "Blog URL",
+    "urlPlaceholder": "https://...",
+    "authorLabel": "Author Name (Optional)",
+    "authorPlaceholder": "Author name (leave blank to auto-extract)",
+    "authorHint": "Leave blank to auto-extract from blog",
+    "button": {
+      "submit": "Add",
+      "submitting": "Processing..."
+    },
+    "toast": {
+      "urlRequired": "Please enter a URL",
+      "invalidUrl": "Please enter a valid URL",
+      "fetchingMetadata": "Fetching metadata...",
+      "saving": "Saving...",
+      "success": "Usage example added successfully!",
+      "error": "Failed to add. Please check the URL."
+    }
+  },
+  "gallery": {
+    "addExample": "Add Usage Example",
+    "editor": "Editor",
+    "failedLoadTemplates": "Failed to load templates. Please try again later.",
+    "noTemplates": "No templates available",
+    "by": "by",
+    "blog": "Blog"
+  },
+  "thankYou": {
+    "title": "Thank you everyone for using Thumbnail Maker 😄",
+    "description": "- Please provide sources when using thumbnails on your blog\n- Your valuable input helps us create a better service for everyone [<a>feedback form</a>]"
+  }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -41,5 +41,63 @@
   "thankYou": {
     "title": "Thank you everyone for using Thumbnail Maker 😄",
     "description": "- Please provide sources when using thumbnails on your blog\n- Your valuable input helps us create a better service for everyone [<a>feedback form</a>]"
+  },
+  "menuBar": {
+    "template": "Template",
+    "goToManyTemplates": "Go to Many Templates",
+    "saveTemplate": "Save Template",
+    "downloadTemplateToLocal": "Download Template to Local",
+    "importTemplate": "Import Template"
+  },
+  "toolbar": {
+    "resetCanvas": "Reset Canvas",
+    "randomShuffle": "Random Shuffle (Ctrl+R)",
+    "dragMode": "Drag Mode",
+    "selectMode": "Select Mode (Ctrl+D)",
+    "wide": "Wide",
+    "square": "Square",
+    "alignLeft": "Align Left",
+    "alignCenter": "Align Center",
+    "alignRight": "Align Right"
+  },
+  "saveTemplate": {
+    "title": "Save Template",
+    "description": "Make the thumbnail you made into a template and share it with others! 🚀",
+    "titleLabel": "Title *",
+    "titlePlaceholder": "Please enter a title",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Please enter a description",
+    "blogUrlLabel": "Blog URL",
+    "blogUrlPlaceholder": "https://",
+    "usernameLabel": "Username",
+    "usernamePlaceholder": "@",
+    "button": "Save Template",
+    "alertTitle": "The added templates are available in the gallery.",
+    "alertDescription": "Only anonymous additions are available at this time.",
+    "toast": {
+      "success": "Template saved successfully",
+      "error": "Error uploading thumbnail"
+    }
+  },
+  "downloadTemplate": {
+    "title": "Download Template",
+    "description": "Download the template you made to your local device.",
+    "cancel": "Cancel",
+    "download": "Download"
+  },
+  "importTemplate": {
+    "title": "Import Template",
+    "warning": "Warning!",
+    "description": "The current content on the canvas will be lost. Are you sure you want to import?",
+    "cancel": "Cancel",
+    "import": "Import"
+  },
+  "subActionMenu": {
+    "downloadImage": "Download Image",
+    "toast": {
+      "title": "Downloaded Successfully",
+      "description": "Share your carefully crafted image with others through the gallery! 🎨",
+      "upload": "Upload"
+    }
   }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -16,7 +16,7 @@
     "urlPlaceholder": "https://...",
     "authorLabel": "저자명 (선택)",
     "authorPlaceholder": "작성자 이름 (비워두면 자동 추출)",
-    "authorHint": "비워두면 블로그에서 자동으로 추출합니다",
+    "authorHint": "비워두면 블로그에서 자동으로 추출됩니다",
     "button": {
       "submit": "추가하기",
       "submitting": "처리 중..."
@@ -26,20 +26,78 @@
       "invalidUrl": "유효한 URL을 입력해주세요",
       "fetchingMetadata": "메타데이터를 가져오는 중...",
       "saving": "저장 중...",
-      "success": "사용 예시가 추가되었습니다!",
+      "success": "사용 예시가 성공적으로 추가되었습니다!",
       "error": "추가에 실패했습니다. URL을 확인해주세요."
     }
   },
   "gallery": {
     "addExample": "사용 예시 추가",
-    "editor": "Editor",
-    "failedLoadTemplates": "템플릿을 불러오는데 실패했습니다. 나중에 다시 시도해주세요.",
+    "editor": "에디터",
+    "failedLoadTemplates": "템플릿을 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
     "noTemplates": "사용 가능한 템플릿이 없습니다",
-    "by": "by",
-    "blog": "Blog"
+    "by": "작성자",
+    "blog": "블로그"
   },
   "thankYou": {
-    "title": "Thumbnail Maker를 사용해주셔서 감사합니다 😄",
-    "description": "- 블로그에서 썸네일을 사용할 때 출처를 명시해주세요\n- 귀하의 소중한 의견은 더 나은 서비스를 만드는 데 도움이 됩니다 [<a>피드백 양식</a>]"
+    "title": "Thumbnail Maker를 이용해주셔서 감사합니다 😄",
+    "description": "- 블로그에서 썸네일을 사용하실 때는 출처를 표기해주세요<br/>- 여러분의 소중한 의견이 더 나은 서비스를 만드는 데 큰 도움이 됩니다. <br/>[<a>피드백 남기기</a>]"
+  },
+  "menuBar": {
+    "template": "템플릿",
+    "goToManyTemplates": "다양한 템플릿 보기",
+    "saveTemplate": "템플릿 저장",
+    "downloadTemplateToLocal": "템플릿을 로컬에 다운로드",
+    "importTemplate": "템플릿 가져오기"
+  },
+  "toolbar": {
+    "resetCanvas": "캔버스 초기화",
+    "randomShuffle": "랜덤 셔플 (Ctrl+R)",
+    "dragMode": "드래그 모드",
+    "selectMode": "선택 모드 (Ctrl+D)",
+    "wide": "Wide",
+    "square": "Square",
+    "alignLeft": "왼쪽 정렬",
+    "alignCenter": "가운데 정렬",
+    "alignRight": "오른쪽 정렬"
+  },
+  "saveTemplate": {
+    "title": "템플릿 저장",
+    "description": "만든 썸네일을 템플릿으로 저장해 다른 사람들과 공유해보세요! 🚀",
+    "titleLabel": "제목 *",
+    "titlePlaceholder": "제목을 입력해주세요",
+    "descriptionLabel": "설명",
+    "descriptionPlaceholder": "설명을 입력해주세요",
+    "blogUrlLabel": "블로그 URL",
+    "blogUrlPlaceholder": "https://",
+    "usernameLabel": "사용자명",
+    "usernamePlaceholder": "@",
+    "button": "템플릿 저장",
+    "alertTitle": "저장된 템플릿은 갤러리에서 확인할 수 있습니다.",
+    "alertDescription": "현재는 익명으로 추가됩니다.",
+    "toast": {
+      "success": "템플릿이 성공적으로 저장되었습니다",
+      "error": "썸네일 업로드 중 오류가 발생했습니다"
+    }
+  },
+  "downloadTemplate": {
+    "title": "템플릿 다운로드",
+    "description": "만든 템플릿을 로컬 장치에 다운로드합니다.",
+    "cancel": "취소",
+    "download": "다운로드"
+  },
+  "importTemplate": {
+    "title": "템플릿 가져오기",
+    "warning": "경고!",
+    "description": "캔버스의 현재 내용이 모두 삭제됩니다. 정말로 가져오시겠습니까?",
+    "cancel": "취소",
+    "import": "가져오기"
+  },
+  "subActionMenu": {
+    "downloadImage": "이미지 다운로드",
+    "toast": {
+      "title": "다운로드 완료",
+      "description": "갤러리를 통해 정성스럽게 만든 이미지를 다른 사람들과 공유해보세요! 🎨",
+      "upload": "업로드"
+    }
   }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -8,5 +8,38 @@
   "linters": "저장 시 모든 코드를 린트합니다",
   "linters-desc": "eslint, prettier, stylelint, commitlint로 구축되었습니다",
   "hero-title": "우리가 사랑하는 최고의 DX로 앱을 개발하세요",
-  "get-started": "시작하기"
+  "get-started": "시작하기",
+  "addBlog": {
+    "title": "사용 예시 추가",
+    "description": "블로그 URL을 입력하면 자동으로 정보를 가져와 추가합니다",
+    "urlLabel": "블로그 URL",
+    "urlPlaceholder": "https://...",
+    "authorLabel": "저자명 (선택)",
+    "authorPlaceholder": "작성자 이름 (비워두면 자동 추출)",
+    "authorHint": "비워두면 블로그에서 자동으로 추출합니다",
+    "button": {
+      "submit": "추가하기",
+      "submitting": "처리 중..."
+    },
+    "toast": {
+      "urlRequired": "URL을 입력해주세요",
+      "invalidUrl": "유효한 URL을 입력해주세요",
+      "fetchingMetadata": "메타데이터를 가져오는 중...",
+      "saving": "저장 중...",
+      "success": "사용 예시가 추가되었습니다!",
+      "error": "추가에 실패했습니다. URL을 확인해주세요."
+    }
+  },
+  "gallery": {
+    "addExample": "사용 예시 추가",
+    "editor": "Editor",
+    "failedLoadTemplates": "템플릿을 불러오는데 실패했습니다. 나중에 다시 시도해주세요.",
+    "noTemplates": "사용 가능한 템플릿이 없습니다",
+    "by": "by",
+    "blog": "Blog"
+  },
+  "thankYou": {
+    "title": "Thumbnail Maker를 사용해주셔서 감사합니다 😄",
+    "description": "- 블로그에서 썸네일을 사용할 때 출처를 명시해주세요\n- 귀하의 소중한 의견은 더 나은 서비스를 만드는 데 도움이 됩니다 [<a>피드백 양식</a>]"
+  }
 }

--- a/src/lib/fetchBlogMetadata.ts
+++ b/src/lib/fetchBlogMetadata.ts
@@ -6,23 +6,67 @@ export interface BlogMetadata {
   url: string;
 }
 
-const CORS_PROXIES = [
-  "https://api.allorigins.win/raw?url=",
-  "https://corsproxy.io/?",
-];
+// CORS_PROXIES를 환경변수에서 읽기 (쉼표로 구분된 문자열)
+function getCorsProxies(): string[] {
+  const envProxies = import.meta.env.VITE_CORS_PROXIES;
+  if (envProxies && typeof envProxies === "string") {
+    return envProxies
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+  }
 
-async function fetchWithProxy(url: string): Promise<string> {
+  // 기본값 (fallback)
+  const defaultProxies = [
+    "https://api.allorigins.win/raw?url=",
+    "https://corsproxy.io/?",
+  ];
+
+  if (!envProxies) {
+    console.warn(
+      "VITE_CORS_PROXIES is not configured. Using default proxies. For production, configure a self-hosted proxy endpoint.",
+    );
+  }
+
+  return defaultProxies;
+}
+
+const CORS_PROXIES = getCorsProxies();
+
+// URL 스키마 검증
+function validateUrl(url: string): void {
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    throw new Error("URL must start with http:// or https://");
+  }
+}
+
+async function fetchWithProxy(url: string, timeoutMs = 5000): Promise<string> {
+  validateUrl(url);
+
   for (const proxy of CORS_PROXIES) {
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), timeoutMs);
+
     try {
       const response = await fetch(proxy + encodeURIComponent(url), {
         headers: {
           Accept: "text/html",
         },
+        signal: abortController.signal,
       });
+
+      clearTimeout(timeoutId);
+
       if (response.ok) {
         return await response.text();
       }
-    } catch {
+    } catch (err) {
+      clearTimeout(timeoutId);
+      if (err instanceof Error && err.name === "AbortError") {
+        // 타임아웃 - 다음 프록시 시도
+        continue;
+      }
+      // 다른 에러도 다음 프록시 시도
       continue;
     }
   }
@@ -46,6 +90,9 @@ function extractMetaContent(html: string, selectors: string[]): string {
 }
 
 export async function fetchBlogMetadata(url: string): Promise<BlogMetadata> {
+  // URL 검증 (방어적 체크)
+  validateUrl(url);
+
   const html = await fetchWithProxy(url);
 
   const title = extractMetaContent(html, [

--- a/src/lib/fetchBlogMetadata.ts
+++ b/src/lib/fetchBlogMetadata.ts
@@ -1,0 +1,82 @@
+export interface BlogMetadata {
+  title: string;
+  description: string;
+  image: string;
+  author?: string;
+  url: string;
+}
+
+const CORS_PROXIES = [
+  "https://api.allorigins.win/raw?url=",
+  "https://corsproxy.io/?",
+];
+
+async function fetchWithProxy(url: string): Promise<string> {
+  for (const proxy of CORS_PROXIES) {
+    try {
+      const response = await fetch(proxy + encodeURIComponent(url), {
+        headers: {
+          Accept: "text/html",
+        },
+      });
+      if (response.ok) {
+        return await response.text();
+      }
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("Failed to fetch URL through all proxies");
+}
+
+function extractMetaContent(html: string, selectors: string[]): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  for (const selector of selectors) {
+    const element = doc.querySelector(selector);
+    if (element) {
+      const content = element.getAttribute("content") || element.textContent;
+      if (content?.trim()) {
+        return content.trim();
+      }
+    }
+  }
+  return "";
+}
+
+export async function fetchBlogMetadata(url: string): Promise<BlogMetadata> {
+  const html = await fetchWithProxy(url);
+
+  const title = extractMetaContent(html, [
+    'meta[property="og:title"]',
+    'meta[name="twitter:title"]',
+    "title",
+  ]);
+
+  const description = extractMetaContent(html, [
+    'meta[property="og:description"]',
+    'meta[name="twitter:description"]',
+    'meta[name="description"]',
+  ]);
+
+  const image = extractMetaContent(html, [
+    'meta[property="og:image"]',
+    'meta[name="twitter:image"]',
+    'meta[name="image"]',
+  ]);
+
+  const author = extractMetaContent(html, [
+    'meta[property="article:author"]',
+    'meta[name="author"]',
+    'meta[property="og:site_name"]',
+  ]);
+
+  return {
+    title: title || "Untitled",
+    description: description || "",
+    image: image || "",
+    author: author || undefined,
+    url,
+  };
+}

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 import { Plus } from "lucide-react";
 import useStorageState from "use-storage-state";
 import { useNavigate } from "react-router-dom";
-// import { AddBlogExampleSheet } from "src/components/template-gallery/AddBlogExampleSheet";
+import { AddBlogExampleSheet } from "src/components/template-gallery/AddBlogExampleSheet";
 import { ScrollArea } from "src/components/ui/scroll-area";
 import GalleryItem, { Template } from "src/components/gallery/GalleryItem";
 import { Tabs, TabsList, TabsTrigger } from "src/components/ui/tabs";
@@ -118,11 +118,11 @@ export default function GalleryPage() {
       </div>
 
       {/* Add Blog Example Sheet */}
-      {/* <AddBlogExampleSheet
+      <AddBlogExampleSheet
         open={isAddSheetOpen}
         onOpenChange={setIsAddSheetOpen}
         onSuccess={handleAddSuccess}
-      /> */}
+      />
     </>
   );
 }

--- a/src/pages/home/ThankYouAlert.tsx
+++ b/src/pages/home/ThankYouAlert.tsx
@@ -1,21 +1,28 @@
+import { useTranslation, Trans } from "react-i18next";
 import { Alert, AlertTitle, AlertDescription } from "src/components/ui/alert";
 
 export function ThankYouAlert() {
+  const { t } = useTranslation("translation");
+
   return (
     <Alert
       variant="outline"
-      className="mb-4 mt-auto h-fit max-w-[260px] bg-[#31353F]"
+      className="mb-4 mt-auto h-fit max-w-[260px] bg-card"
     >
       <div className="flex flex-col gap-2 !pl-1">
-        <AlertTitle>Thank you everyone for using Thumbnail Maker 😄</AlertTitle>
+        <AlertTitle>{t("thankYou.title")}</AlertTitle>
         <AlertDescription>
-          - Please provide sources when using thumbnails on your blog
-          <br />- Your valuable input helps us create a better service for
-          everyone [
-          <a href="https://github.com/sumi-0011/Thumbnail-Maker/issues/new">
-            feedback form
-          </a>
-          ]
+          <Trans
+            i18nKey="thankYou.description"
+            components={{
+              a: (
+                <a
+                  href="https://github.com/sumi-0011/Thumbnail-Maker/issues/new"
+                  className="underline"
+                />
+              ),
+            }}
+          />
         </AlertDescription>
       </div>
     </Alert>

--- a/src/pages/home/ThankYouAlert.tsx
+++ b/src/pages/home/ThankYouAlert.tsx
@@ -21,6 +21,7 @@ export function ThankYouAlert() {
                   className="underline"
                 />
               ),
+              br: <br />,
             }}
           />
         </AlertDescription>

--- a/src/pages/home/ThankYouAlert.tsx
+++ b/src/pages/home/ThankYouAlert.tsx
@@ -1,0 +1,23 @@
+import { Alert, AlertTitle, AlertDescription } from "src/components/ui/alert";
+
+export function ThankYouAlert() {
+  return (
+    <Alert
+      variant="outline"
+      className="mb-4 mt-auto h-fit max-w-[260px] bg-[#31353F]"
+    >
+      <div className="flex flex-col gap-2 !pl-1">
+        <AlertTitle>Thank you everyone for using Thumbnail Maker 😄</AlertTitle>
+        <AlertDescription>
+          - Please provide sources when using thumbnails on your blog
+          <br />- Your valuable input helps us create a better service for
+          everyone [
+          <a href="https://github.com/sumi-0011/Thumbnail-Maker/issues/new">
+            feedback form
+          </a>
+          ]
+        </AlertDescription>
+      </div>
+    </Alert>
+  );
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -69,19 +69,18 @@ export default function Home() {
       </Helmet>
       <FullPageScroller>
         {/* Page 1: Editor */}
-        <Section
-          id="editor"
-          className="relative grid w-full grid-cols-[1fr_minmax(0,782px)_1fr] gap-4 px-4 md:grid-cols-[1fr_782px_1fr]"
-        >
-          <div></div>
-          <PaletteProvider key={`palette-${templateKey}`}>
-            <TagProvider key={`tag-${templateKey}`}>
-              <ThumbnailMaker />
-            </TagProvider>
-          </PaletteProvider>
+        <Section id="editor">
+          <div className="relative grid w-full grid-cols-[1fr_minmax(0,782px)_1fr] gap-4 px-4 md:grid-cols-[1fr_782px_1fr]">
+            <div></div>
+            <PaletteProvider key={`palette-${templateKey}`}>
+              <TagProvider key={`tag-${templateKey}`}>
+                <ThumbnailMaker />
+              </TagProvider>
+            </PaletteProvider>
 
-          <div className="flex justify-end">
-            <ThankYouAlert />
+            <div className="flex justify-end">
+              <ThankYouAlert />
+            </div>
           </div>
 
           <ScrollHint onClick={handleScrollToTemplates} />

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -5,14 +5,17 @@ import { toast } from "sonner";
 import ThumbnailMaker from "src/components/thumbnail-maker";
 import { PaletteProvider } from "src/components/thumbnail-maker/Palette.context";
 import { TagProvider } from "src/components/thumbnail-maker/Tag.context";
-import { Button } from "src/components/ui/button";
-import { FullPageScroller, useScrollToSection } from "src/components/landing/FullPageScroller";
+import {
+  FullPageScroller,
+  useScrollToSection,
+} from "src/components/landing/FullPageScroller";
 import { Section } from "src/components/landing/Section";
 import { ScrollHint } from "src/components/landing/ScrollHint";
 import { TemplateGallery } from "src/components/template-gallery/TemplateGallery";
 import { Template } from "src/components/gallery/GalleryItem";
 import { useSetTemplate } from "src/components/thumbnail-maker/hooks/useSetTemplate";
 import { useUserStats } from "src/hooks/useUserStats";
+import { ThankYouAlert } from "./ThankYouAlert";
 
 export default function Home() {
   const { t } = useTranslation("translation");
@@ -25,31 +28,33 @@ export default function Home() {
     incrementVisit();
   }, []);
 
- 
   const handleScrollToTemplates = useCallback(() => {
     scrollToSection("templates");
   }, [scrollToSection]);
 
-  const handleApplyTemplate = useCallback((template: Template) => {
-    // blog_only 타입은 블로그 링크만 열기
-    if (template.template_type === "blog_only") {
-      if (template.blog_url) {
-        window.open(template.blog_url, "_blank", "noopener,noreferrer");
+  const handleApplyTemplate = useCallback(
+    (template: Template) => {
+      // blog_only 타입은 블로그 링크만 열기
+      if (template.template_type === "blog_only") {
+        if (template.blog_url) {
+          window.open(template.blog_url, "_blank", "noopener,noreferrer");
+        }
+        return;
       }
-      return;
-    }
 
-    // Supabase Template 데이터를 useSetTemplate 형식으로 전달
-    onUseTemplate(template.data);
+      // Supabase Template 데이터를 useSetTemplate 형식으로 전달
+      onUseTemplate(template.data);
 
-    // Provider를 리마운트하여 새로운 상태 반영
-    setTemplateKey((prev) => prev + 1);
+      // Provider를 리마운트하여 새로운 상태 반영
+      setTemplateKey((prev) => prev + 1);
 
-    // 에디터 섹션으로 스크롤
-    scrollToSection("editor");
+      // 에디터 섹션으로 스크롤
+      scrollToSection("editor");
 
-    toast.success("Template applied successfully!");
-  }, [scrollToSection, onUseTemplate]);
+      toast.success("Template applied successfully!");
+    },
+    [scrollToSection, onUseTemplate],
+  );
 
   return (
     <>
@@ -58,17 +63,26 @@ export default function Home() {
       </Helmet>
       <FullPageScroller>
         {/* Page 1: Editor */}
-        <Section id="editor" className="relative">
+        <Section
+          id="editor"
+          className="relative grid grid-cols-[1fr_782px_1fr] gap-4 px-4"
+        >
+          <div></div>
           <PaletteProvider key={`palette-${templateKey}`}>
             <TagProvider key={`tag-${templateKey}`}>
               <ThumbnailMaker />
             </TagProvider>
           </PaletteProvider>
+
+          <div className="flex justify-end">
+            <ThankYouAlert />
+          </div>
+
           <ScrollHint onClick={handleScrollToTemplates} />
         </Section>
 
         {/* Page 2: Template Gallery */}
-        <Section id="templates" className="bg-[#1D2027]">
+        <Section id="templates">
           <TemplateGallery onApply={handleApplyTemplate} />
         </Section>
       </FullPageScroller>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -42,6 +42,12 @@ export default function Home() {
         return;
       }
 
+      // template.data 검증
+      if (!template.data) {
+        console.warn("Template data is missing");
+        return;
+      }
+
       // Supabase Template 데이터를 useSetTemplate 형식으로 전달
       onUseTemplate(template.data);
 
@@ -65,7 +71,7 @@ export default function Home() {
         {/* Page 1: Editor */}
         <Section
           id="editor"
-          className="relative grid grid-cols-[1fr_782px_1fr] gap-4 px-4"
+          className="relative grid w-full grid-cols-[1fr_minmax(0,782px)_1fr] gap-4 px-4 md:grid-cols-[1fr_782px_1fr]"
         >
           <div></div>
           <PaletteProvider key={`palette-${templateKey}`}>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -31,6 +31,14 @@ export default function Home() {
   }, [scrollToSection]);
 
   const handleApplyTemplate = useCallback((template: Template) => {
+    // blog_only 타입은 블로그 링크만 열기
+    if (template.template_type === "blog_only") {
+      if (template.blog_url) {
+        window.open(template.blog_url, "_blank", "noopener,noreferrer");
+      }
+      return;
+    }
+
     // Supabase Template 데이터를 useSetTemplate 형식으로 전달
     onUseTemplate(template.data);
 

--- a/src/styles/globals.less
+++ b/src/styles/globals.less
@@ -101,6 +101,49 @@
   overflow: hidden;
 }
 
+// 일반 스크롤 모드 (작은 화면)
+.full-page-wrapper--normal-scroll {
+  height: auto;
+  min-height: 100vh;
+  overflow: visible;
+}
+
+// 일반 스크롤 모드일 때 모든 부모 컨테이너의 overflow를 override
+body[data-scroll-mode="normal"],
+html:has(body[data-scroll-mode="normal"]) {
+  overflow: auto !important;
+  height: auto !important;
+}
+
+// Layout의 overflow-hidden을 override
+body[data-scroll-mode="normal"] [class*="h-screen"][class*="overflow-hidden"],
+body[data-scroll-mode="normal"] .h-screen.overflow-hidden {
+  overflow: auto !important;
+  height: auto !important;
+  min-height: 100vh !important;
+}
+
+// SidebarInset도 스크롤 가능하도록
+body[data-scroll-mode="normal"] main[class*="SidebarInset"],
+body[data-scroll-mode="normal"] [class*="SidebarInset"] {
+  overflow: visible !important;
+  min-height: auto !important;
+}
+
+// fullpage 스크롤 모드일 때는 기존 동작 유지
+body[data-scroll-mode="fullpage"],
+html:has(body[data-scroll-mode="fullpage"]) {
+  overflow: hidden !important;
+  height: 100vh !important;
+}
+
+// fullpage 스크롤 모드일 때 Layout의 overflow-hidden 유지
+body[data-scroll-mode="fullpage"] [class*="h-screen"][class*="overflow-hidden"],
+body[data-scroll-mode="fullpage"] .h-screen.overflow-hidden {
+  overflow: hidden !important;
+  height: 100vh !important;
+}
+
 .full-page-wrapper .swiper {
   height: 100%;
   width: 100%;
@@ -116,9 +159,24 @@
   overflow: hidden;
 }
 
+// 일반 스크롤 모드에서 섹션 스타일
+.full-page-wrapper--normal-scroll .section {
+  min-height: 840px;
+  height: auto;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+}
+
 .slide-content {
   height: 100%;
   width: 100%;
+}
+
+// 일반 스크롤 모드에서 slide-content 스타일
+.full-page-wrapper--normal-scroll .slide-content {
+  min-height: 840px;
+  height: auto;
 }
 
 // 3D Transform utilities


### PR DESCRIPTION
## 변경사항

- AddBlogExampleSheet 컴포넌트를 TagChangeSheet 스타일에 맞게 디자인 개선
- SheetContent를 center 정렬로 변경
- 라벨 스타일을 일관되게 수정
- SheetFooter를 추가하여 버튼 배치 개선
- 갤러리 페이지에 AddBlogExampleSheet 연결

## 관련 이슈
- 사용 예시 추가 기능의 UI/UX 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 갤러리에 URL로 블로그 예제 추가 UI와 블로그 전용 카드(외부 블로그 버튼) 추가
  * 블로그 전용 템플릿 적용 시 외부 블로그 열기 동작
  * 작은 화면에서 정상 스크롤 모드 지원(풀페이지/일반 스크롤 전환) 및 뷰포트 최적화

* **현지화**
  * 앱 전반에 걸친 다국어(번역) 텍스트 대대적 추가 및 UI 문자열 국제화

* **스타일**
  * 카드 호버 스케일, 버튼 간격, 알림 테두리 등 시각적 미세 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->